### PR TITLE
fix mouse shifting issue for mac

### DIFF
--- a/src/compas_view2/app/selector.py
+++ b/src/compas_view2/app/selector.py
@@ -244,8 +244,8 @@ class Selector:
         """
         self.performing_interactive_selection = False
 
-    def perform_box_selection(self, x, y):
-        """Start or update a box selection session.
+    def reset_box_selection(self, x, y):
+        """Reset box selection start position
 
         Parameters
         ----------
@@ -258,10 +258,27 @@ class Selector:
         -------
         None
         """
-        # initialize the box selection session if needed
-        if self.select_from != "box":
-            self.select_from = "box"
-            # Set the start mouse location
-            self.box_select_coords[:2] = x, y
+        # Set the start mouse location
+        self.box_select_coords[:2] = x, y
+
+    def perform_box_selection(self, x, y):
+        """Update a box selection session.
+
+        Parameters
+        ----------
+        x : int
+            current x coordinate of the mouse
+        y : int
+            current y coordinate of the mouse
+
+        Returns
+        -------
+        None
+        """
         # Set the current mouse location
-        self.box_select_coords[2:] = x, y
+        box_width = abs(x - self.box_select_coords[0])
+        box_height = abs(y - self.box_select_coords[1])
+
+        if box_width > 0 and box_height > 0:
+            self.select_from = "box"
+            self.box_select_coords[2:] = x, y

--- a/src/compas_view2/views/view.py
+++ b/src/compas_view2/views/view.py
@@ -131,6 +131,10 @@ class View(QtWidgets.QOpenGLWidget):
             return
         if event.buttons() & QtCore.Qt.LeftButton:
             self.mouse.buttons['left'] = True
+            if self.app.selector.enabled:
+                if self.keys["shift"] or self.keys["control"]:
+                    self.app.selector.reset_box_selection(
+                        event.pos().x(), event.pos().y())
         elif event.buttons() & QtCore.Qt.RightButton:
             self.mouse.buttons['right'] = True
         self.mouse.last_pos = event.pos()


### PR DESCRIPTION
On mac, mouse click sometimes trigger the mouseMoveEvent without moving, causing a box selection with 0 size.  This is to prevent a zero-sized box to register as valid box selection session.
