### PR TITLE
add feature to create geometries on grid

### DIFF
--- a/src/compas_view2/app/config.json
+++ b/src/compas_view2/app/config.json
@@ -64,6 +64,7 @@
                     "items":
                     [
                         {"type": "action", "text": "Add Point", "action": "add_point"},
+                        {"type": "action", "text": "Add Point On Grid", "action": "add_point_on_grid"},
                         {"type": "action", "text": "Add Line [2 points]", "action": "add_line_from_selected_points"}
                     ]
                 },

--- a/src/compas_view2/app/controller.py
+++ b/src/compas_view2/app/controller.py
@@ -146,9 +146,19 @@ class Controller:
             return point
 
     @interactive
+    def add_point_on_grid(self) -> Union[Point, None]:
+        self.app.statusbar.showMessage("Select a location on grid")
+        location = self.app.selector.start_selection_on_plane(snap_to_grid=True)
+        if location:
+            self.app.statusbar.showMessage("Created a Point.")
+            return Point(*location)
+        else:
+            self.app.statusbar.showMessage("No location provided.")
+            return None
+
+    @interactive
     def add_line_from_selected_points(self):
-        self.app.statusbar.showMessage(
-            "Select points on screen, Click Enter to finish")
+        self.app.statusbar.showMessage("Select points on screen, Click Enter to finish")
         points = self.app.selector.start_selection(types=[Point])
         if len(points) != 2:
             self.app.statusbar.showMessage("Must select 2 points")

--- a/src/compas_view2/app/selector.py
+++ b/src/compas_view2/app/selector.py
@@ -246,6 +246,22 @@ class Selector:
         return selected_data
 
     def start_selection_on_plane(self, snap_to_grid=False):
+        """Start an interactive selection session to pick a location on the grid plane.
+
+        Parameters
+        ----------
+        snap_to_grid : bool
+            Whether to snap the location on the grid
+
+        Returns
+        -------
+        List of 3 float numbers, selected location on the plane
+
+        Notes
+        -----
+        This function has to be called inside a interactive (non-blocking) session,
+        Otherwise it will freeze the main programme.
+        """
         self.performing_interactive_selection_on_plane = True
         self.snap_to_grid = snap_to_grid
         while self.performing_interactive_selection_on_plane:
@@ -253,6 +269,19 @@ class Selector:
         return self.selected_location_on_plane
 
     def finish_selection_on_plane(self, x, y):
+        """Finish selecting location on the grid plane.
+
+        Parameters
+        ----------
+        x : int
+            mouse x coordinate on uv_plane_map
+        y : int
+            mouse y coordinate on uv_plane_map
+
+        Returns
+        -------
+        None
+        """
         u, v, w = self.app.selector.uv_plane_map[y, x]
         if [u, v, w] == [1, 1, 1]:
             # When clicked outside of the grid

--- a/src/compas_view2/app/selector.py
+++ b/src/compas_view2/app/selector.py
@@ -20,6 +20,9 @@ class Selector:
         self.select_from = "pixel"  # or "box"
         self.paint_instance = False
         self.box_select_coords = np.zeros((4,), np.int)
+        self.performing_interactive_selection = False
+        self.performing_interactive_selection_on_plane = False
+        self.snap_to_grid = False
         self.start_monitor_instance_map()
 
     def reset(self):
@@ -32,6 +35,9 @@ class Selector:
         self.select_from = "pixel"
         self.paint_instance = False
         self.box_select_coords = np.zeros((4,), np.int)
+        self.performing_interactive_selection = False
+        self.performing_interactive_selection_on_plane = False
+        self.snap_to_grid = False
         self.deselect()
 
     def start_monitor_instance_map(self):
@@ -239,10 +245,34 @@ class Selector:
         self.reset()
         return selected_data
 
+    def start_selection_on_plane(self, snap_to_grid=False):
+        self.performing_interactive_selection_on_plane = True
+        self.snap_to_grid = snap_to_grid
+        while self.performing_interactive_selection_on_plane:
+            time.sleep(0.05)
+        return self.selected_location_on_plane
+
+    def finish_selection_on_plane(self, x, y):
+        u, v, w = self.app.selector.uv_plane_map[y, x]
+        if [u, v, w] == [1, 1, 1]:
+            # When clicked outside of the grid
+            self.selected_location_on_plane = None
+        else:
+            x_size = self.app.view.grid.x_cells * self.app.view.grid.cell_size
+            y_size = self.app.view.grid.y_cells * self.app.view.grid.cell_size
+            x = -x_size + 2*x_size*u
+            y = -y_size + 2*y_size*v
+            if self.snap_to_grid:
+                x = round(x / self.app.view.grid.cell_size) * self.app.view.grid.cell_size
+                y = round(y / self.app.view.grid.cell_size) * self.app.view.grid.cell_size
+            self.selected_location_on_plane = [x, y, 0]
+        self.performing_interactive_selection_on_plane = False
+
     def finish_selection(self):
         """Finish the interactive selection session.
         """
         self.performing_interactive_selection = False
+        self.performing_interactive_selection_on_plane = False
 
     def reset_box_selection(self, x, y):
         """Reset box selection start position

--- a/src/compas_view2/objects/gridobject.py
+++ b/src/compas_view2/objects/gridobject.py
@@ -78,6 +78,19 @@ class GridObject(Object):
             'n': len(elements)
         }
 
+        x_size = self.x_cells * self.cell_size
+        y_size = self.y_cells * self.cell_size
+        positions = [[-x_size, -y_size, 0], [x_size, -y_size, 0], [x_size, y_size, 0], [-x_size, y_size, 0]]
+        color = [[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]]
+        elements = [[0, 1, 3], [1, 2, 3], [1, 0, 3], [2, 1, 3]]
+
+        self._uvplane = {
+            'positions': make_vertex_buffer(list(flatten(positions))),
+            'colors': make_vertex_buffer(list(flatten(color))),
+            'elements': make_index_buffer(list(flatten(elements))),
+            'n': len(list(flatten(elements))),
+        }
+
     def draw(self, shader):
         shader.enable_attribute('position')
         shader.enable_attribute('color')
@@ -88,5 +101,16 @@ class GridObject(Object):
         shader.draw_lines(elements=self.edges['elements'], n=self.edges['n'])
 
         # reset
+        shader.disable_attribute('position')
+        shader.disable_attribute('color')
+
+    def draw_plane(self, shader):
+        shader.enable_attribute('position')
+        shader.enable_attribute('color')
+
+        shader.bind_attribute('position', self._uvplane['positions'])
+        shader.bind_attribute('color', self._uvplane['colors'])
+        shader.draw_triangles(elements=self._uvplane['elements'], n=self._uvplane['n'])
+
         shader.disable_attribute('position')
         shader.disable_attribute('color')

--- a/src/compas_view2/views/view.py
+++ b/src/compas_view2/views/view.py
@@ -163,9 +163,15 @@ class View(QtWidgets.QOpenGLWidget):
                 self.app.selector.instance_map = self.paint_instances(self.app.selector.box_select_coords)
             self.app.selector.paint_instance = False
             self.clear()
+        if self.app.selector.performing_interactive_selection_on_plane:
+            self.app.selector.uv_plane_map = self.paint_plane()
+            self.clear()
         self.paint()
         if self.app.selector.select_from == "box":
             self.shader.draw_2d_box(self.app.selector.box_select_coords, self.app.width, self.app.height)
+
+    def paint_plane(self):
+        pass
 
     def paint_instances(self):
         pass
@@ -200,8 +206,7 @@ class View(QtWidgets.QOpenGLWidget):
             self.mouse.buttons['left'] = True
             if self.app.selector.enabled:
                 if self.keys["shift"] or self.keys["control"]:
-                    self.app.selector.reset_box_selection(
-                        event.pos().x(), event.pos().y())
+                    self.app.selector.reset_box_selection(event.pos().x(), event.pos().y())
         elif event.buttons() & QtCore.Qt.RightButton:
             self.mouse.buttons['right'] = True
         self.mouse.last_pos = event.pos()
@@ -213,7 +218,10 @@ class View(QtWidgets.QOpenGLWidget):
         if event.button() == QtCore.Qt.MouseButton.LeftButton:
             self.mouse.buttons['left'] = False
             if self.app.selector.enabled:
-                self.app.selector.paint_instance = True
+                if self.app.selector.performing_interactive_selection_on_plane:
+                    self.app.selector.finish_selection_on_plane(event.pos().x(), event.pos().y())
+                else:
+                    self.app.selector.paint_instance = True
 
         elif event.button() == QtCore.Qt.MouseButton.RightButton:
             self.mouse.buttons['right'] = False

--- a/src/compas_view2/views/view120.py
+++ b/src/compas_view2/views/view120.py
@@ -59,9 +59,22 @@ class View120(View):
         self.shader.release()
         # create map
         r = self.devicePixelRatio()
-        instance_buffer = GL.glReadPixels(
-            x*r, y*r, width*r, height*r, GL.GL_RGB, GL.GL_UNSIGNED_BYTE)
-        instance_map = np.frombuffer(
-            instance_buffer, dtype=np.uint8).reshape(height*r, width*r, 3)
+        instance_buffer = GL.glReadPixels(x*r, y*r, width*r, height*r, GL.GL_RGB, GL.GL_UNSIGNED_BYTE)
+        instance_map = np.frombuffer(instance_buffer, dtype=np.uint8).reshape(height*r, width*r, 3)
         instance_map = instance_map[::-r, ::r, :]
         return instance_map
+
+    def paint_plane(self):
+
+        x, y, width, height = 0, 0, self.app.width, self.app.height
+
+        self.shader.bind()
+        self.shader.uniform4x4("viewworld", self.camera.viewworld())
+        self.grid.draw_plane(self.shader)
+        self.shader.release()
+
+        r = self.devicePixelRatio()
+        plane_uv_map = GL.glReadPixels(x*r, y*r, width*r, height*r, GL.GL_RGB, GL.GL_FLOAT)
+        plane_uv_map = plane_uv_map.reshape(height*r, width*r, 3)
+        plane_uv_map = plane_uv_map[::-r, ::r, :]
+        return plane_uv_map


### PR DESCRIPTION
prototyping the feature to add objects on grid /xy plane. It's done through painting a uv plane at same extent of the grid object. where the red and green channel represent the u and v coords of the plane. a snap_to_grid option is also provided by rounding up with the grid cell size.

Question: should we allow the click-able area extend outside of the grid?