### PR TITLE
grid in background

### DIFF
--- a/src/compas_view2/objects/gridobject.py
+++ b/src/compas_view2/objects/gridobject.py
@@ -85,7 +85,7 @@ class GridObject(Object):
 
         shader.bind_attribute('position', self.edges['positions'])
         shader.bind_attribute('color', self.edges['colors'])
-        shader.draw_lines(elements=self.edges['elements'], n=self.edges['n'])
+        shader.draw_lines(elements=self.edges['elements'], n=self.edges['n'], background=True)
 
         # reset
         shader.disable_attribute('position')

--- a/src/compas_view2/shaders/shader.py
+++ b/src/compas_view2/shaders/shader.py
@@ -92,11 +92,14 @@ class Shader:
         else:
             GL.glDrawArrays(GL.GL_TRIANGLES, 0, GL.GL_BUFFER_SIZE)
 
-    def draw_lines(self, elements=None, n=0, width=1):
+    def draw_lines(self, elements=None, n=0, width=1, background=False):
         if elements:
+            if background:
+                GL.glDisable(GL.GL_DEPTH_TEST)
             GL.glLineWidth(width)
             GL.glBindBuffer(GL.GL_ELEMENT_ARRAY_BUFFER, elements)
             GL.glDrawElements(GL.GL_LINES, n, GL.GL_UNSIGNED_INT, None)
+            GL.glEnable(GL.GL_DEPTH_TEST)
         else:
             GL.glDrawArrays(GL.GL_LINES, 0, GL.GL_BUFFER_SIZE)
 


### PR DESCRIPTION
#17  Making grid to the background by turning of the depth test. So it does not overlap, see the purple polyline.  
However it also goes behind everything, see the cube at origin
![image](https://user-images.githubusercontent.com/17893605/106734224-0f2dbe80-6613-11eb-80c7-673559486d6b.png)
