### PR TITLE
move update matrix to object update

### DIFF
--- a/src/compas_view2/objects/bufferobject.py
+++ b/src/compas_view2/objects/bufferobject.py
@@ -109,6 +109,7 @@ class BufferObject(Object):
 
     def update(self):
         """Update the object"""
+        self._update_matrix()
         self.update_buffers()
 
     def draw(self, shader, wireframe=False):

--- a/src/compas_view2/objects/object.py
+++ b/src/compas_view2/objects/object.py
@@ -105,7 +105,6 @@ class Object(ABC):
     @property
     def matrix(self):
         """Get the updated matrix from object's translation, rotation and scale"""
-        self._update_matrix()
         return self._transformation.matrix
 
     @matrix.setter


### PR DESCRIPTION
#46 Now the update matrix is only called with `obj.update()` rather than each draw function. @GeneKao Could you check if it helps on you computer?