### PR TITLE
add custom object opacity

### DIFF
--- a/scripts/v120_scripted.py
+++ b/scripts/v120_scripted.py
@@ -32,6 +32,6 @@ for point in cloud.transformed(R1):
     size = random.random()
     box = Box((point, [1, 0, 0], [0, 1, 0]), size, size, size)
     color = i_to_rgb(random.random(), normalize=True)
-    viewer.add(box, show_points=False, color=color)
+    viewer.add(box, show_points=False, color=color, opacity=random.random())
 
 viewer.show()

--- a/src/compas_view2/objects/bufferobject.py
+++ b/src/compas_view2/objects/bufferobject.py
@@ -26,7 +26,7 @@ class BufferObject(Object):
     default_color_backfaces = [0.8, 0.8, 0.8]
 
     def __init__(self, data, name=None, is_selected=False, show_points=False,
-                 show_lines=False, show_faces=False, linewidth=1, pointsize=10):
+                 show_lines=False, show_faces=False, linewidth=1, pointsize=10, opacity=1):
         super().__init__(data, name=name, is_selected=is_selected)
         self._data = data
         self.show_points = show_points
@@ -34,6 +34,7 @@ class BufferObject(Object):
         self.show_faces = show_faces
         self.linewidth = linewidth
         self.pointsize = pointsize
+        self.opacity = opacity
 
     def make_buffer_from_data(self, data):
         """Create buffers from point/line/face data.
@@ -119,6 +120,7 @@ class BufferObject(Object):
         shader.uniform1i('is_selected', self.is_selected)
         shader.uniform4x4('transform', self.matrix)
         shader.uniform1i('is_lighted', is_lighted)
+        shader.uniform1f('object_opacity', self.opacity)
         if hasattr(self, "_frontfaces_buffer") and self.show_faces and not wireframe:
             shader.bind_attribute('position', self._frontfaces_buffer['positions'])
             shader.bind_attribute('color', self._frontfaces_buffer['colors'])
@@ -140,6 +142,7 @@ class BufferObject(Object):
             shader.bind_attribute('color', self._points_buffer['colors'])
             shader.draw_points(size=self.pointsize, elements=self._points_buffer['elements'], n=self._points_buffer['n'])
         shader.uniform1i('is_selected', 0)
+        shader.uniform1f('object_opacity', 1)
         shader.disable_attribute('position')
         shader.disable_attribute('color')
 

--- a/src/compas_view2/objects/meshobject.py
+++ b/src/compas_view2/objects/meshobject.py
@@ -54,8 +54,11 @@ class MeshObject(BufferObject):
                  facecolor=None, linecolor=None, pointcolor=None,
                  color=None,
                  linewidth=1, pointsize=10,
-                 hide_coplanaredges=False):
-        super().__init__(data, name=name, is_selected=is_selected, show_points=show_points, show_lines=show_lines, show_faces=show_faces, linewidth=linewidth, pointsize=pointsize)
+                 hide_coplanaredges=False, opacity=1):
+        super().__init__(
+            data, name=name, is_selected=is_selected, show_points=show_points,
+            show_lines=show_lines, show_faces=show_faces, linewidth=linewidth,
+            pointsize=pointsize, opacity=opacity)
         self._mesh = data
         self._pointcolor = None
         self._linecolor = None

--- a/src/compas_view2/shaders/120/mesh.frag
+++ b/src/compas_view2/shaders/120/mesh.frag
@@ -4,6 +4,7 @@ varying vec3 vertex_color;
 varying vec3 ec_pos;
 
 uniform float opacity;
+uniform float object_opacity;
 uniform bool is_instance_mask;
 uniform bool is_lighted;
 uniform vec3 instance_color;
@@ -18,9 +19,9 @@ void main()
         if (is_lighted){
             vec3 ec_normal = normalize(cross(dFdx(ec_pos), dFdy(ec_pos)));
             vec3 L = normalize(-ec_pos); 
-            gl_FragColor = vec4(vertex_color * dot(ec_normal, L), opacity);
+            gl_FragColor = vec4(vertex_color * dot(ec_normal, L), opacity * object_opacity);
         }else{
-            gl_FragColor = vec4(vertex_color, opacity);
+            gl_FragColor = vec4(vertex_color, opacity * object_opacity);
         }
     }
 


### PR DESCRIPTION
#20 
All objects now have an custom opacity at 1 by default, which is multiplied with the app-wide opacity in shader
![image](https://user-images.githubusercontent.com/17893605/109797073-4050dd00-7c19-11eb-93cf-2e6078e40a77.png)
