### PR TITLE
raise type error for unsupported data

### DIFF
--- a/src/compas_view2/objects/object.py
+++ b/src/compas_view2/objects/object.py
@@ -38,7 +38,11 @@ class Object(ABC):
     @staticmethod
     def build(data, **kwargs):
         """Build an object class according to its corrensponding data type"""
-        return DATA_VIEW[data.__class__](data, **kwargs)
+        try:
+            obj = DATA_VIEW[data.__class__](data, **kwargs)
+        except KeyError:
+            raise TypeError("Type {} is not supported by the viewer.".format(type(data)))
+        return obj
 
     def __init__(self, data, name=None, is_selected=False):
         self._data = data


### PR DESCRIPTION
```python
from compas_view2 import app

viewer = app.App()
viewer.add({})
viewer.show()

```

```bash
Traceback (most recent call last):
  File "d:/Github/compas_view2/scripts/v120_unregistered.py", line 4, in <module>    
    viewer.add({})
  File "d:\github\compas_view2\src\compas_view2\app\app.py", line 174, in add        
    obj = Object.build(data, **kwargs)
  File "d:\github\compas_view2\src\compas_view2\objects\object.py", line 44, in build
    raise TypeError("Type {} is not supported by the viewer.".format(type(data)))
TypeError: Type <class 'dict'> is not supported by the viewer.
```