### PR TITLE
Use matrix buffer

### DIFF
--- a/src/compas_view2/app/app.py
+++ b/src/compas_view2/app/app.py
@@ -207,7 +207,11 @@ class App:
 
     def status(self, message):
         """Display a message in the status bar."""
-        self.statusbar.showMessage(message)
+        self.statusText.setText(message)
+
+    def fps(self, _fps):
+        """Update fps info in the status bar."""
+        self.statusFps.setText("fps: {}".format(_fps))
 
     # ==============================================================================
     # UI
@@ -219,7 +223,10 @@ class App:
     def _init_statusbar(self):
         self.statusbar = self.window.statusBar()
         self.statusbar.setContentsMargins(0, 0, 0, 0)
-        self.statusbar.showMessage('Ready')
+        self.statusText = QtWidgets.QLabel("Ready")
+        self.statusbar.addWidget(self.statusText, 1)
+        self.statusFps = QtWidgets.QLabel("fps: ")
+        self.statusbar.addWidget(self.statusFps)
 
     def _init_menubar(self, items):
         if not items:

--- a/src/compas_view2/app/controller.py
+++ b/src/compas_view2/app/controller.py
@@ -188,35 +188,35 @@ class Controller:
 
     @interactive("add")
     def add_point_on_grid(self) -> Union[Point, None]:
-        self.app.statusbar.showMessage("Select a location on grid")
+        self.app.status("Select a location on grid")
         location = self.app.selector.start_selection_on_plane(snap_to_grid=True)
         if location:
-            self.app.statusbar.showMessage("Created a Point.")
+            self.app.status("Created a Point.")
             return Point(*location)
         else:
-            self.app.statusbar.showMessage("No location provided.")
+            self.app.status("No location provided.")
             return None
 
     @interactive("add")
     def add_line_from_selected_points(self):
-        self.app.statusbar.showMessage("Select points on screen, Click Enter to finish")
+        self.app.status("Select points on screen, Click Enter to finish")
         points = self.app.selector.start_selection(types=[Point])
         if len(points) != 2:
-            self.app.statusbar.showMessage("Must select 2 points")
+            self.app.status("Must select 2 points")
             return None
         line = Line(*points)
-        self.app.statusbar.showMessage("Line added")
+        self.app.status("Line added")
         return line
 
     @interactive("edit")
     def edit_selected_object(self):
-        self.app.statusbar.showMessage("Select one object on screen, Click Enter to finish")
+        self.app.status("Select one object on screen, Click Enter to finish")
         if len(self.app.selector.selected) == 1:
             return self.app.selector.selected[0]
         else:
             objects = self.app.selector.start_selection(types=[Point], mode="single", returns="object")
             if len(objects) != 1:
-                self.app.statusbar.showMessage("Must select 1 object")
+                self.app.status("Must select 1 object")
                 return None
             return objects[0]
 

--- a/src/compas_view2/objects/bufferobject.py
+++ b/src/compas_view2/objects/bufferobject.py
@@ -119,7 +119,7 @@ class BufferObject(Object):
         shader.enable_attribute('position')
         shader.enable_attribute('color')
         shader.uniform1i('is_selected', self.is_selected)
-        shader.uniform4x4('transform', self.matrix)
+        shader.uniform4x4('transform', self._matrix_buffer)
         shader.uniform1i('is_lighted', is_lighted)
         shader.uniform1f('object_opacity', self.opacity)
         if hasattr(self, "_frontfaces_buffer") and self.show_faces and not wireframe:
@@ -153,7 +153,7 @@ class BufferObject(Object):
         shader.enable_attribute('color')
         shader.uniform1i('is_instance_mask', 1)
         shader.uniform3f('instance_color', self._instance_color)
-        shader.uniform4x4('transform', self.matrix)
+        shader.uniform4x4('transform', self._matrix_buffer)
         if hasattr(self, "_points_buffer") and self.show_points:
             shader.bind_attribute('position', self._points_buffer['positions'])
             shader.draw_points(size=self.pointsize, elements=self._points_buffer['elements'], n=self._points_buffer['n'])

--- a/src/compas_view2/objects/object.py
+++ b/src/compas_view2/objects/object.py
@@ -4,6 +4,7 @@ from compas.geometry import Translation
 from compas.geometry import Rotation
 from compas.geometry import Scale
 from compas.geometry import decompose_matrix
+import numpy as np
 
 
 ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()})
@@ -53,6 +54,7 @@ class Object(ABC):
         self._rotation = [0, 0, 0]
         self._scale = [1, 1, 1]
         self._transformation = Transformation()
+        self._matrix_buffer = np.array(self.matrix).flatten()
 
     @abc.abstractmethod
     def init(self):
@@ -105,6 +107,7 @@ class Object(ABC):
         S1 = Scale.from_factors(self.scale)
         M = T1 * R1 * S1
         self._transformation.matrix = M.matrix
+        self._matrix_buffer = np.array(self.matrix).flatten()
 
     @property
     def matrix(self):

--- a/src/compas_view2/views/view.py
+++ b/src/compas_view2/views/view.py
@@ -5,6 +5,7 @@ from PySide2 import QtCore, QtWidgets
 from ..camera import Camera
 from ..mouse import Mouse
 from ..objects import GridObject
+import time
 
 
 class View(QtWidgets.QOpenGLWidget):
@@ -54,6 +55,8 @@ class View(QtWidgets.QOpenGLWidget):
         self.grid = GridObject(1, 10, 10)
         self.objects = {}
         self.keys = {"shift": False, "control": False}
+        self._frames = 0
+        self._now = time.time()
 
     @property
     def mode(self):
@@ -175,6 +178,11 @@ class View(QtWidgets.QOpenGLWidget):
         """
         self.clear()
         self.paint()
+        self._frames += 1
+        if time.time() - self._now > 1:
+            self._now = time.time()
+            self.app.fps(self._frames)
+            self._frames = 0
 
     def paint(self):
         pass


### PR DESCRIPTION
On topic of #62 , added an fps counter, after some investigation, instead of inside shader, the bottle-neck turned out to be causde by assigning the matrix as uniform. Especially for simple objects like points/lines, where the size of matrix becomes even larger than the position/color/elements buffers. In these scenarios passing matrices to gpu becomes relatively high cost, and additionally slowed down by flattening them all the time. So adding a pre-flattened buffer partially helps. Here are some benckmarks:

2000 Lines
Current: 5 fps
By passing matrix uniforms: 7 fps
Using pre-flattened matrix: 6 fps

1000 Lines
Current: 9 fps
By passing matrix uniforms: 13 fps
Using pre-flattened matrix: 11 fps
