### PR TITLE
Performance

### DIFF
--- a/src/compas_view2/objects/bufferobject.py
+++ b/src/compas_view2/objects/bufferobject.py
@@ -120,7 +120,7 @@ class BufferObject(Object):
         shader.enable_attribute('position')
         shader.enable_attribute('color')
         shader.uniform1i('is_selected', self.is_selected)
-        if self._matrix_updated:
+        if self._matrix_buffer is not None:
             shader.uniform4x4('transform', self._matrix_buffer)
         shader.uniform1i('is_lighted', is_lighted)
         shader.uniform1f('object_opacity', self.opacity)
@@ -146,9 +146,8 @@ class BufferObject(Object):
             shader.draw_points(size=self.pointsize, elements=self._points_buffer['elements'], n=self._points_buffer['n'], background=self.background)
         shader.uniform1i('is_selected', 0)
         shader.uniform1f('object_opacity', 1)
-        if self._matrix_updated:
+        if self._matrix_buffer is not None:
             shader.uniform4x4('transform', np.identity(4).flatten())
-            self._matrix_updated = False
         shader.disable_attribute('position')
         shader.disable_attribute('color')
 

--- a/src/compas_view2/objects/bufferobject.py
+++ b/src/compas_view2/objects/bufferobject.py
@@ -1,6 +1,7 @@
 from compas.utilities import flatten
 from ..buffers import make_index_buffer, make_vertex_buffer, update_vertex_buffer, update_index_buffer
 from .object import Object
+import numpy as np
 
 
 class BufferObject(Object):
@@ -119,7 +120,8 @@ class BufferObject(Object):
         shader.enable_attribute('position')
         shader.enable_attribute('color')
         shader.uniform1i('is_selected', self.is_selected)
-        shader.uniform4x4('transform', self._matrix_buffer)
+        if self._matrix_updated:
+            shader.uniform4x4('transform', self._matrix_buffer)
         shader.uniform1i('is_lighted', is_lighted)
         shader.uniform1f('object_opacity', self.opacity)
         if hasattr(self, "_frontfaces_buffer") and self.show_faces and not wireframe:
@@ -144,6 +146,9 @@ class BufferObject(Object):
             shader.draw_points(size=self.pointsize, elements=self._points_buffer['elements'], n=self._points_buffer['n'], background=self.background)
         shader.uniform1i('is_selected', 0)
         shader.uniform1f('object_opacity', 1)
+        if self._matrix_updated:
+            shader.uniform4x4('transform', np.identity(4).flatten())
+            self._matrix_updated = False
         shader.disable_attribute('position')
         shader.disable_attribute('color')
 

--- a/src/compas_view2/objects/object.py
+++ b/src/compas_view2/objects/object.py
@@ -55,6 +55,7 @@ class Object(ABC):
         self._scale = [1, 1, 1]
         self._transformation = Transformation()
         self._matrix_buffer = np.array(self.matrix).flatten()
+        self._matrix_updated = False
 
     @abc.abstractmethod
     def init(self):
@@ -108,6 +109,7 @@ class Object(ABC):
         M = T1 * R1 * S1
         self._transformation.matrix = M.matrix
         self._matrix_buffer = np.array(self.matrix).flatten()
+        self._matrix_updated = True
 
     @property
     def matrix(self):

--- a/src/compas_view2/objects/object.py
+++ b/src/compas_view2/objects/object.py
@@ -54,8 +54,7 @@ class Object(ABC):
         self._rotation = [0, 0, 0]
         self._scale = [1, 1, 1]
         self._transformation = Transformation()
-        self._matrix_buffer = np.array(self.matrix).flatten()
-        self._matrix_updated = False
+        self._matrix_buffer = None
 
     @abc.abstractmethod
     def init(self):
@@ -109,7 +108,6 @@ class Object(ABC):
         M = T1 * R1 * S1
         self._transformation.matrix = M.matrix
         self._matrix_buffer = np.array(self.matrix).flatten()
-        self._matrix_updated = True
 
     @property
     def matrix(self):

--- a/src/compas_view2/views/view120.py
+++ b/src/compas_view2/views/view120.py
@@ -21,6 +21,7 @@ class View120(View):
         self.shader.bind()
         self.shader.uniform4x4("projection", self.camera.projection(self.app.width, self.app.height))
         self.shader.uniform4x4("viewworld", self.camera.viewworld())
+        self.shader.uniform4x4("transform", np.identity(4))
         self.shader.uniform1i("is_selected", 0)
         self.shader.uniform1f("opacity", self.opacity)
         self.shader.uniform3f("selection_color", self.selection_color)


### PR DESCRIPTION
Continue on #63  , this ought to do it. So a `_matrix_buffer` is now initiated as `None` , and will only be assigned if matrix has been changed at least once.

The shader will be preloaded with an identity matrix. In draw iterations, when an object's `_matrix_buffer` is None, it will simply skip it.
