### PR TITLE
Kwargs

### DIFF
--- a/scripts/v120_collection.py
+++ b/scripts/v120_collection.py
@@ -1,6 +1,6 @@
 from compas_view2 import app
 from compas.geometry import Sphere
-from compas.geometry import Line
+from compas.geometry import Polyline
 from compas_view2.collections import Collection
 from random import random
 
@@ -18,12 +18,12 @@ for x in range(5):
 
 
 spherecollection = Collection(spheres)
-viewer.add(spherecollection, colors=colors)
+viewer.add(spherecollection, colors=colors, u=20, v=5, linecolor=(0.2, 0, 0), show_edges=True)
 
 lines = []
 colors = []
-for i in range(1000):
-    line = Line((random()*5 + 5, random()*5, random()*5), (random()*5 + 5, random()*5, random()*5))
+for i in range(100):
+    line = Polyline([(random()*5 + 5, random()*5, random()*5), (random()*5 + 5, random()*5, random()*5), (random()*5 + 5, random()*5, random()*5)])
     lines.append(line)
     colors.append((random(), random(), random()))
 

--- a/scripts/v120_mesh_display.py
+++ b/scripts/v120_mesh_display.py
@@ -13,7 +13,7 @@ mesh.transform(T*S)
 
 mesh2 = mesh.transformed(Translation.from_vector([-6, 0, 0]))
 
-viewer.add(mesh, show_vertices=False, hide_coplanaredges=False)
-viewer.add(mesh2, show_vertices=False, hide_coplanaredges=True)
+viewer.add(mesh, show_edges=True, hide_coplanaredges=False)
+viewer.add(mesh2, show_edges=True, hide_coplanaredges=True)
 
 viewer.show()

--- a/scripts/v120_points.py
+++ b/scripts/v120_points.py
@@ -6,9 +6,9 @@ from random import random
 viewer = app.App()
 for i in range(10):
     point = Point(random()*10, random()*10, random()*10)
-    viewer.add(point, color=(random(), random(), random()), size=10)
+    viewer.add(point, color=(random(), random(), random()), size=30)
 
 cloud = Pointcloud.from_bounds(5, 5, 5, 1000)
-viewer.add(cloud, color=(random(), random(), random()), size=10)
+viewer.add(cloud, color=(random(), random(), random()))
 
 viewer.show()

--- a/scripts/v120_scripted.py
+++ b/scripts/v120_scripted.py
@@ -13,7 +13,7 @@ from compas_view2 import app
 viewer = app.App()
 
 mesh = Mesh.from_off(compas.get('tubemesh.off'))
-viewer.add(mesh, show_vertices=False)
+viewer.add(mesh, show_edges=True)
 
 network = Network.from_obj(compas.get('grid_irregular.obj'))
 viewer.add(network)
@@ -23,7 +23,7 @@ T = Translation.from_vector([-10, 20, 0])
 R = Rotation.from_axis_and_angle([1, 0, 0], math.radians(90))
 S = Scale.from_factors([100, 100, 100])
 bunny.transform(T * R * S)
-viewer.add(bunny, show_vertices=False)
+viewer.add(bunny, show_edges=True)
 
 cloud = Pointcloud.from_bounds(10, 5, 3, 100)
 
@@ -32,6 +32,6 @@ for point in cloud.transformed(R1):
     size = random.random()
     box = Box((point, [1, 0, 0], [0, 1, 0]), size, size, size)
     color = i_to_rgb(random.random(), normalize=True)
-    viewer.add(box, show_vertices=False, color=color, opacity=random.random())
+    viewer.add(box, show_edges=True, color=color, opacity=random.random())
 
 viewer.show()

--- a/src/compas_view2/objects/bufferobject.py
+++ b/src/compas_view2/objects/bufferobject.py
@@ -26,15 +26,16 @@ class BufferObject(Object):
     default_color_frontfaces = [0.8, 0.8, 0.8]
     default_color_backfaces = [0.8, 0.8, 0.8]
 
-    def __init__(self, data, name=None, is_selected=False, show_points=False,
-                 show_lines=False, show_faces=False, linewidth=1, pointsize=10, opacity=1):
+    def __init__(self, data, name=None, is_selected=False,
+                 show_points=False, show_vertices=False, show_lines=False, show_edges=False,
+                 show_faces=True, linewidth=None, pointsize=None, opacity=1):
         super().__init__(data, name=name, is_selected=is_selected)
         self._data = data
-        self.show_points = show_points
-        self.show_lines = show_lines
+        self.show_points = show_points or show_vertices
+        self.show_lines = show_lines or show_edges
         self.show_faces = show_faces
-        self.linewidth = linewidth
-        self.pointsize = pointsize
+        self.linewidth = linewidth or 1
+        self.pointsize = pointsize or 10
         self.opacity = opacity
         self.background = False
         self._bounding_box = None

--- a/src/compas_view2/objects/collectionobject.py
+++ b/src/compas_view2/objects/collectionobject.py
@@ -1,18 +1,24 @@
 from .object import Object
 from .bufferobject import BufferObject
 import numpy as np
+from inspect import getargspec
 
 
 class CollectionObject(BufferObject):
     """Object for displaying COMPAS collection."""
 
     def __init__(self, collection, color=None, colors=None, **kwargs):
-        super().__init__(collection, **kwargs)
+
+        argspec = getargspec(BufferObject.__init__)
+        BufferObject_keywords = argspec.args[-len(argspec.defaults):]
+        BufferObject_kwargs = {key: kwargs[key] for key in kwargs if key in BufferObject_keywords}
+        super().__init__(collection, **BufferObject_kwargs)
+
         colors = colors or [color or [0.5, 0.5, 0.5]] * len(self._data.items)
-        self._objects = [Object.build(item, color=color) for item, color in zip(self._data.items, colors)]
+        self._objects = [Object.build(item, color=color, **kwargs) for item, color in zip(self._data.items, colors)]
 
         # if not given explicitly, use child object default settings
-        self.show_points = self.show_lines or self._objects[0].show_points
+        self.show_points = self.show_points or self._objects[0].show_points
         self.show_lines = self.show_lines or self._objects[0].show_lines
         self.show_faces = self.show_faces or self._objects[0].show_faces
 

--- a/src/compas_view2/objects/frameobject.py
+++ b/src/compas_view2/objects/frameobject.py
@@ -4,14 +4,8 @@ from .bufferobject import BufferObject
 class FrameObject(BufferObject):
     """Object for displaying COMPAS Frame geometry."""
 
-    def __init__(self,
-                 data,
-                 name=None,
-                 is_selected=False,
-                 show_point=True,
-                 pointsize=10,
-                 linewidth=1):
-        super().__init__(data, name=name, is_selected=is_selected, show_points=show_point, show_lines=True, pointsize=pointsize, linewidth=linewidth)
+    def __init__(self, data, show_point=True, show_lines=True, **kwargs):
+        super().__init__(data, show_points=show_point, show_lines=show_lines, **kwargs)
 
     def _points_data(self):
         frame = self._data

--- a/src/compas_view2/objects/lineobject.py
+++ b/src/compas_view2/objects/lineobject.py
@@ -7,18 +7,8 @@ class LineObject(BufferObject):
     default_color_points = [0.1, 0.1, 0.1]
     default_color_lines = [0.4, 0.4, 0.4]
 
-    def __init__(self,
-                 data,
-                 name=None,
-                 is_selected=False,
-                 show_points=False,
-                 pointcolor=None,
-                 pointsize=10,
-                 linecolor=None,
-                 linewidth=1,
-                 color=None
-                 ):
-        super().__init__(data, name=name, is_selected=is_selected, show_lines=True, show_points=show_points, pointsize=pointsize, linewidth=linewidth)
+    def __init__(self, data, show_lines=True, pointcolor=None, linecolor=None, color=None, **kwargs):
+        super().__init__(data, show_lines=show_lines, **kwargs)
         self.pointcolor = pointcolor or color
         self.linecolor = linecolor or color
 

--- a/src/compas_view2/objects/meshobject.py
+++ b/src/compas_view2/objects/meshobject.py
@@ -69,24 +69,18 @@ class MeshObject(BufferObject):
     default_color_lines = [0.4, 0.4, 0.4]
     default_color_faces = [0.8, 0.8, 0.8]
 
-    def __init__(self, data, name=None, is_selected=False,
-                 show_vertices=False, show_edges=True, show_faces=True,
+    def __init__(self, data, color=None,
                  facecolor=None, linecolor=None, pointcolor=None,
-                 color=None,
-                 linewidth=1, pointsize=10,
-                 hide_coplanaredges=False, opacity=1,
-                 vertices=None, edges=None, faces=None):
-        super().__init__(
-            data, name=name, is_selected=is_selected, show_points=show_vertices,
-            show_lines=show_edges, show_faces=show_faces, linewidth=linewidth,
-            pointsize=pointsize, opacity=opacity)
+                 vertices=None, edges=None, faces=None,
+                 hide_coplanaredges=False, **kwargs):
+        super().__init__(data,  **kwargs)
         self._mesh = data
         self._pointcolor = None
         self._linecolor = None
         self._facecolor = None
-        self.facecolor = color or facecolor
-        self.linecolor = color or linecolor
-        self.pointcolor = color or pointcolor
+        self.facecolor = facecolor or color
+        self.linecolor = linecolor or color
+        self.pointcolor = pointcolor or color
         self.hide_coplanaredges = hide_coplanaredges
         self.vertices = vertices
         self.edges = edges

--- a/src/compas_view2/objects/networkobject.py
+++ b/src/compas_view2/objects/networkobject.py
@@ -7,8 +7,8 @@ class NetworkObject(BufferObject):
     default_color_points = [0.1, 0.1, 0.1]
     default_color_lines = [0.4, 0.4, 0.4]
 
-    def __init__(self, data, name=None, is_selected=False, show_points=True, show_lines=True):
-        super().__init__(data, name=name, is_selected=is_selected, show_points=show_points, show_lines=show_lines)
+    def __init__(self, data, show_points=True, show_lines=True, **kwargs):
+        super().__init__(data, show_points=show_points, show_lines=show_lines, **kwargs)
 
     @property
     def nodes(self):

--- a/src/compas_view2/objects/pointcloudobject.py
+++ b/src/compas_view2/objects/pointcloudobject.py
@@ -28,8 +28,8 @@ class PointcloudObject(BufferObject):
         If number of colors does not equal to number of points.
     """
 
-    def __init__(self, data, name=None, is_selected=False, color=None, colors=None, size=10):
-        super().__init__(data, name=name, is_selected=is_selected, show_points=True, pointsize=size)
+    def __init__(self, data, color=None, colors=None, size=10, **kwargs):
+        super().__init__(data, show_points=True, pointsize=size, **kwargs)
         self.colors = colors or [color or self.default_color_points] * len(data)
         if len(self.colors) != len(data):
             raise ValueError("Number of colors must equal to number of points")

--- a/src/compas_view2/objects/pointobject.py
+++ b/src/compas_view2/objects/pointobject.py
@@ -5,8 +5,8 @@ from ..forms import PointEditForm
 class PointObject(BufferObject):
     """Object for displaying COMPAS point geometry."""
 
-    def __init__(self, data, name=None, is_selected=False, color=None, size=10):
-        super().__init__(data, name=name, is_selected=is_selected, show_points=True, pointsize=size)
+    def __init__(self, data, color=None, size=10, **kwargs):
+        super().__init__(data, show_points=True, pointsize=size, **kwargs)
         self.color = color
 
     def _points_data(self):

--- a/src/compas_view2/objects/polylineobject.py
+++ b/src/compas_view2/objects/polylineobject.py
@@ -7,17 +7,8 @@ class PolylineObject(BufferObject):
     default_color_points = [0.1, 0.1, 0.1]
     default_color_line = [0.4, 0.4, 0.4]
 
-    def __init__(self,
-                 data,
-                 name=None,
-                 is_selected=False,
-                 show_points=False,
-                 pointcolor=None,
-                 pointsize=10,
-                 linecolor=None,
-                 color=None,
-                 linewidth=1):
-        super().__init__(data, name=name, show_lines=True, is_selected=is_selected, show_points=show_points, linewidth=linewidth, pointsize=pointsize)
+    def __init__(self, data, pointcolor=None, linecolor=None, color=None, **kwargs):
+        super().__init__(data, show_lines=True, **kwargs)
         self.pointcolor = pointcolor or color
         self.linecolor = linecolor or color
 


### PR DESCRIPTION
This is related to #78 . The idea is to use kwargs whenever possible at init of objects. So that we can make the code cleaner and at same time allow passing through the kwargs to child objects when creating collection. The updated `v120_collection.py` shows how it's working:
```python
spheres = []
colors = []

for x in range(5):
    for y in range(5):
        for z in range(5):
            sphere = Sphere([x, y, z], 0.2)
            spheres.append(sphere)
            colors.append((x/5, y/5, z/5))


spherecollection = Collection(spheres)
viewer.add(spherecollection, colors=colors, u=20, v=5, linecolor=(0.2, 0, 0), show_edges=True)
```
![image](https://user-images.githubusercontent.com/17893605/114689692-422cb680-9d16-11eb-91a6-a930df22dae6.png)

