### PR TITLE
Updated Color APIs

### DIFF
--- a/scripts/v120_colors.py
+++ b/scripts/v120_colors.py
@@ -1,4 +1,3 @@
-from os import name
 import compas
 
 from compas_view2 import app

--- a/scripts/v120_colors.py
+++ b/scripts/v120_colors.py
@@ -1,0 +1,28 @@
+import compas
+
+from compas_view2 import app
+from compas.datastructures import Mesh
+from compas.geometry import Translation, Scale
+from random import random
+
+viewer = app.App(width=800, height=500)
+
+mesh = Mesh.from_obj(compas.get('faces.obj'))
+T = Translation.from_vector([0, 0, 1])
+S = Scale.from_factors([.5, .5, .5])
+mesh.transform(T*S)
+
+mesh2 = mesh.transformed(Translation.from_vector([-6, 0, 0]))
+
+facecolors = {k: [random(), random(), random()] for k in mesh.faces()}
+linecolors = {k: [random(), random(), random()] for k in mesh.edges()}
+pointcolors = {k: [random(), random(), random()] for k in mesh.vertices()}
+pointcolors = {k: [0.5, 0, 0] for k in mesh.vertices()}
+
+# viewer.add(mesh, show_points=True, facecolors=facecolors, linecolors=linecolors, pointcolors=pointcolors)
+# viewer.add(mesh, show_points=True, facecolors=facecolors, linecolors=linecolors, pointcolors=pointcolors)
+viewer.add(mesh, show_points=True, facecolors=facecolors, linecolors=linecolors, pointcolor=[0.3, 0, 0])
+# viewer.add(mesh, hide_coplanaredges=False, facecolor=[0.99, 0.0, 0])
+# viewer.add(mesh2, hide_coplanaredges=True)
+
+viewer.show()

--- a/scripts/v120_colors.py
+++ b/scripts/v120_colors.py
@@ -1,3 +1,4 @@
+from os import name
 import compas
 
 from compas_view2 import app
@@ -17,12 +18,8 @@ mesh2 = mesh.transformed(Translation.from_vector([-6, 0, 0]))
 facecolors = {k: [random(), random(), random()] for k in mesh.faces()}
 linecolors = {k: [random(), random(), random()] for k in mesh.edges()}
 pointcolors = {k: [random(), random(), random()] for k in mesh.vertices()}
-pointcolors = {k: [0.5, 0, 0] for k in mesh.vertices()}
 
-# viewer.add(mesh, show_points=True, facecolors=facecolors, linecolors=linecolors, pointcolors=pointcolors)
-# viewer.add(mesh, show_points=True, facecolors=facecolors, linecolors=linecolors, pointcolors=pointcolors)
-viewer.add(mesh, show_points=True, facecolors=facecolors, linecolors=linecolors, pointcolor=[0.3, 0, 0])
-# viewer.add(mesh, hide_coplanaredges=False, facecolor=[0.99, 0.0, 0])
-# viewer.add(mesh2, hide_coplanaredges=True)
+viewer.add(mesh, name="mesh1", show_points=True, facecolors=facecolors, linecolors=linecolors, pointcolors=pointcolors)
+viewer.add(mesh2, name="mesh2", show_points=True, facecolor=[1, 0, 0], linecolor=[0, 1, 0], pointcolor=[0, 0, 1])
 
 viewer.show()

--- a/scripts/v120_points.py
+++ b/scripts/v120_points.py
@@ -9,6 +9,7 @@ for i in range(10):
     viewer.add(point, color=(random(), random(), random()), size=30)
 
 cloud = Pointcloud.from_bounds(5, 5, 5, 1000)
-viewer.add(cloud, color=(random(), random(), random()))
+colors = {i: [random(), random(), random()] for i in range(1000)}
+viewer.add(cloud, colors=colors)
 
 viewer.show()

--- a/src/compas_view2/forms/editform.py
+++ b/src/compas_view2/forms/editform.py
@@ -3,6 +3,7 @@ from compas.datastructures import Mesh
 from compas.datastructures import Network
 from compas.datastructures import VolMesh
 from .collapsiblebox import CollapsibleBox
+import numpy as np
 
 
 class EditForm(QtWidgets.QDockWidget):
@@ -33,16 +34,30 @@ class EditForm(QtWidgets.QDockWidget):
         self.obj = obj
         self.on_update = on_update
 
+        # Show object class
+        self.add_label(obj.name)
         self.add_label(obj._data.__class__)
 
+        # Map object transform
         self.map_transform(obj)
 
+        # Map object visualisation settings
+        cb = self.add_collapsiblebox("Visualisation")
+        v_layout = QtWidgets.QVBoxLayout()
+        v_layout._parent = cb
+        
+        cb.setContentLayout(v_layout)
+        self.map_object(obj, obj.visualisation, layout=v_layout)
+
+        # Map custom object properties
         if obj.properties:
             cb = self.add_collapsiblebox("Object")
             v_layout = QtWidgets.QVBoxLayout()
-            self.map_dict(obj, keys=obj.properties, layout=v_layout)
+            v_layout._parent = cb
+            self.map_object(obj, obj.properties, layout=v_layout, update_data=True)
             cb.setContentLayout(v_layout)
 
+        # Map object data
         if hasattr(obj._data, "data"):
             cb = self.add_collapsiblebox("Data")
             v_layout = QtWidgets.QVBoxLayout()
@@ -51,7 +66,7 @@ class EditForm(QtWidgets.QDockWidget):
             if type(obj._data) in [Mesh, Network, VolMesh]:
                 self.add_label(type(obj._data).__name__, layout=v_layout)
             else:
-                self.map_data(self.data, layout=v_layout)
+                self.map_inputs(self.data, layout=v_layout, update_data=True)
             cb.setContentLayout(v_layout)
 
         self._inputs.addStretch()
@@ -74,81 +89,98 @@ class EditForm(QtWidgets.QDockWidget):
         return cb
 
     def map_transform(self, obj):
-
+        """Map the transformation of an object"""
         cb = self.add_collapsiblebox("Transform")
         v_layout = QtWidgets.QVBoxLayout()
 
         self.add_label("translation", layout=v_layout)
         layout = QtWidgets.QHBoxLayout()
         v_layout.addLayout(layout)
-        self.map_number(obj.translation, 0, name="x", layout=layout, update_data=False)
-        self.map_number(obj.translation, 1, name="y", layout=layout, update_data=False)
-        self.map_number(obj.translation, 2, name="z", layout=layout, update_data=False)
+        self.map_number(obj.translation, 0, name="x", layout=layout)
+        self.map_number(obj.translation, 1, name="y", layout=layout)
+        self.map_number(obj.translation, 2, name="z", layout=layout)
 
         self.add_label("rotation", layout=v_layout)
         layout = QtWidgets.QHBoxLayout()
         v_layout.addLayout(layout)
-        self.map_number(obj.rotation, 0, name="x", layout=layout, update_data=False)
-        self.map_number(obj.rotation, 1, name="y", layout=layout, update_data=False)
-        self.map_number(obj.rotation, 2, name="z", layout=layout, update_data=False)
+        self.map_number(obj.rotation, 0, name="x", layout=layout)
+        self.map_number(obj.rotation, 1, name="y", layout=layout)
+        self.map_number(obj.rotation, 2, name="z", layout=layout)
 
         self.add_label("scale", layout=v_layout)
         layout = QtWidgets.QHBoxLayout()
         v_layout.addLayout(layout)
-        self.map_number(obj.scale, 0, name="x", layout=layout, update_data=False)
-        self.map_number(obj.scale, 1, name="y", layout=layout, update_data=False)
-        self.map_number(obj.scale, 2, name="z", layout=layout, update_data=False)
+        self.map_number(obj.scale, 0, name="x", layout=layout)
+        self.map_number(obj.scale, 1, name="y", layout=layout)
+        self.map_number(obj.scale, 2, name="z", layout=layout)
 
         cb.setContentLayout(v_layout)
 
-    def map_data(self, data, name=None, layout=None):
+    def map_inputs(self, data, name=None, layout=None, is_color=False, update_data=False):
+        """Map inputs of supported data type"""
         if name:
             self.add_label(name, layout=layout)
-        if isinstance(data, list):
-            if isinstance(data[0], float) or isinstance(data[0], int):
-                self.map_list(data, layout=layout)
+        if isinstance(data, list) or isinstance(data, np.ndarray):
+            if is_color:
+                self.map_color(data, layout=layout, update_data=update_data)
+            elif isinstance(data[0], float) or isinstance(data[0], int):
+                self.map_list(data, layout=layout, update_data=update_data)
             elif len(data) <= 10 and (isinstance(data[0][0], float) or isinstance(data[0][0], int)):
-                self.map_vector_list(data, layout=layout)
+                self.map_vector_list(data, layout=layout, update_data=update_data)
             else:
                 self.add_label(f"{data[0].__class__.__name__}[{len(data)}]", layout=layout)
         elif isinstance(data, dict):
-            self.map_dict(data, layout=layout)
+            self.map_dict(data, layout=layout, update_data=update_data)
         else:
             raise TypeError("Un-supported data type")
 
-    def map_dict(self, data, keys=None, layout=None):
+    def map_object(self, data, attrs, layout=None, update_data=False):
+        """Map the attributs of an object"""
+        for attr in attrs:
+            attribute = getattr(data, attr)
+            if isinstance(attribute, bool):
+                self.map_bool(data, attr, layout=layout, update_data=update_data)
+            elif isinstance(attribute, int) or isinstance(attribute, float):
+                self.map_number(data, attr, layout=layout, update_data=update_data)
+            else:
+                cb = self.add_collapsiblebox(attr, layout=layout)
+                v_layout = QtWidgets.QVBoxLayout()
+                v_layout._parent = cb
+                is_color = isinstance(attribute, np.ndarray) and attr.endswith("color") # TODO: Use color class
+                self.map_inputs(attribute, layout=v_layout, is_color=is_color, update_data=update_data)
+                cb.setContentLayout(v_layout)
 
-        if keys:
-            for key in keys:
-                self.map_number(data, key, layout=layout)
-        else:
-            for key in data:
-                if isinstance(data[key], int) or isinstance(data[key], float):
-                    self.map_number(data, key, layout=layout)
-                else:
-                    cb = self.add_collapsiblebox(key, layout=layout)
-                    v_layout = QtWidgets.QVBoxLayout()
-                    v_layout._parent = cb
-                    self.map_data(data[key], layout=v_layout)
-                    cb.setContentLayout(v_layout)
+    def map_dict(self, data, layout=None, update_data=False):
+        """Map a dictionary input"""
+        for key in data:
+            if isinstance(data[key], int) or isinstance(data[key], float):
+                self.map_number(data, key, layout=layout, update_data=update_data)
+            else:
+                cb = self.add_collapsiblebox(key, layout=layout)
+                v_layout = QtWidgets.QVBoxLayout()
+                v_layout._parent = cb
+                self.map_inputs(data[key], layout=v_layout, update_data=update_data)
+                cb.setContentLayout(v_layout)
 
-    def map_vector_list(self, _list, layout=None):
+    def map_vector_list(self, _list, layout=None, update_data=False):
+        """Map a list of vetors"""
         v_layout = QtWidgets.QVBoxLayout()
         v_layout.setContentsMargins(20, 0, 0, 0)
         layout.addLayout(v_layout)
         for i, vector in enumerate(_list):
-            self.map_list(vector, name=i, layout=v_layout)
+            self.map_list(vector, name=i, layout=v_layout, update_data=update_data)
 
-    def map_list(self, _list, name=None, layout=None):
+    def map_list(self, _list, name=None, layout=None, update_data=False):
+        """Map a list of numbers"""
         h_layout = QtWidgets.QHBoxLayout()
         layout = layout or self._inputs
         layout.addLayout(h_layout)
         if name is not None:
             self.add_label(str(name) + ": ", layout=h_layout)
         for i in range(len(_list)):
-            self.map_number(_list, i, layout=h_layout)
+            self.map_number(_list, i, layout=h_layout, update_data=update_data)
 
-    def map_number(self, obj, attribute, name=None, layout=None, update_data=True):
+    def map_number(self, obj, attribute, name=None, layout=None, update_data=False, minimum=float('-inf'), maximum=float('inf'), step=None):
         """Map number input field to an object attribute
 
         Parameters
@@ -168,46 +200,80 @@ class EditForm(QtWidgets.QDockWidget):
 
         # layout.setContentsMargins(0, 0, 0, 0)
         label = QtWidgets.QLabel(name or str(attribute))
-        if isinstance(obj, list) or isinstance(obj, dict):
+        if type(obj) in [list, dict, np.ndarray]:
             value = obj[attribute]
         else:
             value = getattr(obj, attribute)
         if isinstance(value, float):
             _input = QtWidgets.QDoubleSpinBox()
-            _input.setMinimum(float('-inf'))
-            _input.setMaximum(float('inf'))
+            _input.setSingleStep(0.1)
+            _input.setMinimum(minimum)
+            _input.setMaximum(maximum)
         elif isinstance(value, int):
             _input = QtWidgets.QSpinBox()
         else:
             raise ValueError()
+        if step:
+            _input.setSingleStep(step)
         _input.setValue(value)
         layout.addWidget(label)
         layout.addWidget(_input)
 
         def set_number(value):
-            if isinstance(obj, list) or isinstance(obj, dict):
+            if type(obj) in [list, dict, np.ndarray]:
                 obj[attribute] = value
             else:
                 setattr(obj, attribute, value)
-
-            if hasattr(self, "data"):
-                self.obj._data.data = self.data
-
-            if update_data:
-                self.obj.update()
-            else:
-                self.obj._update_matrix()
-
-            if self.on_update:
-                self.on_update()
+            self.update(update_data)
 
         _input.valueChanged.connect(set_number)
         return layout
 
-    def map_color(self, obj, attribute):
+    def map_color(self, color, layout=None, update_data=False):
         """Map color input field to an object attribute
         """
-        raise NotImplementedError()
+        h_layout = QtWidgets.QHBoxLayout()
+        layout = layout or self._inputs
+        layout.addLayout(h_layout)
+        for i, channel in enumerate(["r", "g", "b"]):
+            self.map_number(color, i, name=channel, layout=h_layout, update_data=update_data, minimum=0, maximum=1, step=0.01)
+
+    def map_bool(self, obj, attribute, name=None,layout=None, update_data=False):
+        """Map color input field to an object attribute
+        """
+        if not layout:
+            layout = QtWidgets.QHBoxLayout()
+            self._inputs.addLayout(layout)
+
+        if type(obj) in [list, dict, np.ndarray]:
+            value = obj[attribute]
+        else:
+            value = getattr(obj, attribute)
+        _input = QtWidgets.QCheckBox(name or str(attribute))
+        _input.setChecked(value)
+        layout.addWidget(_input)
+
+        def set_bool(value):
+            if type(obj) in [list, dict, np.ndarray]:
+                obj[attribute] = value
+            else:
+                setattr(obj, attribute, value)
+            self.update(update_data)
+
+        _input.stateChanged.connect(set_bool)
+        return layout
+
+    def update(self, update_data):
+        if update_data:
+            if hasattr(self, "data"):
+                self.obj._data.data = self.data
+            self.obj.update()
+        else:
+            self.obj._update_matrix()
+
+        if self.on_update:
+            self.on_update()
+
 
     def inputs(self):
         """Creates layout for input fields

--- a/src/compas_view2/forms/editform.py
+++ b/src/compas_view2/forms/editform.py
@@ -45,7 +45,7 @@ class EditForm(QtWidgets.QDockWidget):
         cb = self.add_collapsiblebox("Visualisation")
         v_layout = QtWidgets.QVBoxLayout()
         v_layout._parent = cb
-        
+
         cb.setContentLayout(v_layout)
         self.map_object(obj, obj.visualisation, layout=v_layout)
 
@@ -146,7 +146,7 @@ class EditForm(QtWidgets.QDockWidget):
                 cb = self.add_collapsiblebox(attr, layout=layout)
                 v_layout = QtWidgets.QVBoxLayout()
                 v_layout._parent = cb
-                is_color = isinstance(attribute, np.ndarray) and attr.endswith("color") # TODO: Use color class
+                is_color = isinstance(attribute, np.ndarray) and attr.endswith("color")  # TODO: Use color class
                 self.map_inputs(attribute, layout=v_layout, is_color=is_color, update_data=update_data)
                 cb.setContentLayout(v_layout)
 
@@ -238,7 +238,7 @@ class EditForm(QtWidgets.QDockWidget):
         for i, channel in enumerate(["r", "g", "b"]):
             self.map_number(color, i, name=channel, layout=h_layout, update_data=update_data, minimum=0, maximum=1, step=0.01)
 
-    def map_bool(self, obj, attribute, name=None,layout=None, update_data=False):
+    def map_bool(self, obj, attribute, name=None, layout=None, update_data=False):
         """Map color input field to an object attribute
         """
         if not layout:
@@ -273,7 +273,6 @@ class EditForm(QtWidgets.QDockWidget):
 
         if self.on_update:
             self.on_update()
-
 
     def inputs(self):
         """Creates layout for input fields

--- a/src/compas_view2/forms/editform.py
+++ b/src/compas_view2/forms/editform.py
@@ -120,12 +120,12 @@ class EditForm(QtWidgets.QDockWidget):
         """Map inputs of supported data type"""
         if name:
             self.add_label(name, layout=layout)
-        if isinstance(data, list) or isinstance(data, np.ndarray):
+        if isinstance(data, (list, np.ndarray)):
             if is_color:
                 self.map_color(data, layout=layout, update_data=update_data)
-            elif isinstance(data[0], float) or isinstance(data[0], int):
+            elif isinstance(data[0], (float, int)):
                 self.map_list(data, layout=layout, update_data=update_data)
-            elif len(data) <= 10 and (isinstance(data[0][0], float) or isinstance(data[0][0], int)):
+            elif len(data) <= 10 and isinstance(data[0][0], (float, int)):
                 self.map_vector_list(data, layout=layout, update_data=update_data)
             else:
                 self.add_label(f"{data[0].__class__.__name__}[{len(data)}]", layout=layout)
@@ -140,7 +140,7 @@ class EditForm(QtWidgets.QDockWidget):
             attribute = getattr(data, attr)
             if isinstance(attribute, bool):
                 self.map_bool(data, attr, layout=layout, update_data=update_data)
-            elif isinstance(attribute, int) or isinstance(attribute, float):
+            elif isinstance(attribute, (int, float)):
                 self.map_number(data, attr, layout=layout, update_data=update_data)
             else:
                 cb = self.add_collapsiblebox(attr, layout=layout)
@@ -153,7 +153,7 @@ class EditForm(QtWidgets.QDockWidget):
     def map_dict(self, data, layout=None, update_data=False):
         """Map a dictionary input"""
         for key in data:
-            if isinstance(data[key], int) or isinstance(data[key], float):
+            if isinstance(data[key], (float, int)):
                 self.map_number(data, key, layout=layout, update_data=update_data)
             else:
                 cb = self.add_collapsiblebox(key, layout=layout)
@@ -211,6 +211,12 @@ class EditForm(QtWidgets.QDockWidget):
             _input.setMaximum(maximum)
         elif isinstance(value, int):
             _input = QtWidgets.QSpinBox()
+            if minimum == float('-inf'):
+                minimum = -10**9
+            if maximum == float('inf'):
+                maximum = 10**9
+            _input.setMinimum(minimum)
+            _input.setMaximum(maximum)
         else:
             raise ValueError()
         if step:
@@ -266,7 +272,11 @@ class EditForm(QtWidgets.QDockWidget):
     def update(self, update_data):
         if update_data:
             if hasattr(self, "data"):
-                self.obj._data.data = self.data
+                try:
+                    self.obj._data.data = self.data
+                except Exception as e:
+                    print(e)
+                    print("Failed to update data of", self.obj)
             self.obj.update()
         else:
             self.obj._update_matrix()

--- a/src/compas_view2/objects/bufferobject.py
+++ b/src/compas_view2/objects/bufferobject.py
@@ -40,7 +40,7 @@ class BufferObject(Object):
         self.pointcolor = np.array(pointcolor or color or self.default_color_points, dtype=float)
         self.linecolor = np.array(linecolor or color or self.default_color_lines, dtype=float)
         self.facecolor = np.array(facecolor or color or self.default_color_faces, dtype=float)
-       
+
         self.pointcolors = pointcolors or {}
         self.facecolors = facecolors or {}
         self.linecolors = linecolors or {}

--- a/src/compas_view2/objects/bufferobject.py
+++ b/src/compas_view2/objects/bufferobject.py
@@ -28,8 +28,8 @@ class BufferObject(Object):
     def __init__(self, data, name=None, is_selected=False, is_visible=True,
                  show_points=False, show_vertices=False, show_lines=False, show_edges=True, show_faces=True,
                  pointcolor=None, linecolor=None, facecolor=None, color=None,
-                 facecolors={}, linecolors={}, pointcolors={},
-                 linewidth=1, pointsize=10, opacity=1):
+                 facecolors=None, linecolors=None, pointcolors=None,
+                 linewidth=None, pointsize=None, opacity=None):
         super().__init__(data, name=name, is_selected=is_selected, is_visible=is_visible)
         self._data = data
 
@@ -37,22 +37,33 @@ class BufferObject(Object):
         self.show_lines = show_lines or show_edges
         self.show_faces = show_faces
 
-        self.pointcolor = list(pointcolor or color or self.default_color_points)
-        self.linecolor = list(linecolor or color or self.default_color_lines)
-        self.facecolor = list(facecolor or color or self.default_color_faces)
+        self.pointcolor = np.array(pointcolor or color or self.default_color_points, dtype=float)
+        self.linecolor = np.array(linecolor or color or self.default_color_lines, dtype=float)
+        self.facecolor = np.array(facecolor or color or self.default_color_faces, dtype=float)
        
-        self.pointcolors = pointcolors
-        self.facecolors = facecolors
-        self.linecolors = linecolors
+        self.pointcolors = pointcolors or {}
+        self.facecolors = facecolors or {}
+        self.linecolors = linecolors or {}
 
-        self.linewidth = linewidth
-        self.pointsize = pointsize
+        self.linewidth = linewidth or 1
+        self.pointsize = pointsize or 10
 
-        self.opacity = opacity
+        self.opacity = float(opacity or 1)
         self.background = False
 
         self._bounding_box = None
         self._bounding_box_center = None
+
+    @property
+    def visualisation(self):
+        options = ["opacity"]
+        if hasattr(self, "_points_data"):
+            options += ["pointcolor", "show_points", "pointsize"]
+        if hasattr(self, "_lines_data"):
+            options += ["linecolor", "show_lines", "linewidth"]
+        if hasattr(self, "_frontfaces_data"):
+            options += ["facecolor", "show_faces"]
+        return options
 
     @property
     def bounding_box(self):

--- a/src/compas_view2/objects/frameobject.py
+++ b/src/compas_view2/objects/frameobject.py
@@ -8,13 +8,12 @@ class FrameObject(BufferObject):
     def __init__(self, data, show_point=True, show_lines=True, size=1.0, **kwargs):
         super().__init__(data, show_points=show_point, show_lines=show_lines, **kwargs)
         self.size = size
+        self.linecolors = [(1, 0, 0), (1, 0, 0), (0, 1, 0), (0, 1, 0), (0, 0, 1), (0, 0, 1)]
 
     def _points_data(self):
         frame = self._data
-        # points
-        color = (0, 0, 0)
         positions = [frame.point]
-        colors = [color]
+        colors = [self.pointcolor]
         elements = [[0]]
         return positions, colors, elements
 
@@ -24,7 +23,7 @@ class FrameObject(BufferObject):
             frame.point, frame.point + (frame.xaxis * self.size),
             frame.point, frame.point + (frame.yaxis * self.size),
             frame.point, frame.point + (frame.zaxis * self.size)]
-        colors = [(1, 0, 0), (1, 0, 0), (0, 1, 0), (0, 1, 0), (0, 0, 1), (0, 0, 1)]
+        colors = self.linecolors
         elements = [[0, 1], [2, 3], [4, 5]]
         return positions, colors, elements
 

--- a/src/compas_view2/objects/lineobject.py
+++ b/src/compas_view2/objects/lineobject.py
@@ -8,14 +8,12 @@ class LineObject(BufferObject):
     default_color_points = [0.1, 0.1, 0.1]
     default_color_lines = [0.4, 0.4, 0.4]
 
-    def __init__(self, data, show_lines=True, pointcolor=None, linecolor=None, color=None, **kwargs):
+    def __init__(self, data, show_lines=True, **kwargs):
         super().__init__(data, show_lines=show_lines, **kwargs)
-        self.pointcolor = pointcolor or color
-        self.linecolor = linecolor or color
 
     def _points_data(self):
         line = self._data
-        color = self.pointcolor or self.default_color_points
+        color = self.pointcolor
         positions = [line.start, line.end]
         colors = [color, color]
         elements = [[0], [1]]
@@ -23,7 +21,7 @@ class LineObject(BufferObject):
 
     def _lines_data(self):
         line = self._data
-        color = self.linecolor or self.default_color_lines
+        color = self.linecolor
         positions = [line.start, line.end]
         colors = [color, color]
         elements = [[0, 1]]

--- a/src/compas_view2/objects/lineobject.py
+++ b/src/compas_view2/objects/lineobject.py
@@ -8,8 +8,8 @@ class LineObject(BufferObject):
     default_color_points = [0.1, 0.1, 0.1]
     default_color_lines = [0.4, 0.4, 0.4]
 
-    def __init__(self, data, show_lines=True, **kwargs):
-        super().__init__(data, show_lines=show_lines, **kwargs)
+    def __init__(self, data, **kwargs):
+        super().__init__(data, show_lines=True, **kwargs)
 
     def _points_data(self):
         line = self._data

--- a/src/compas_view2/objects/meshobject.py
+++ b/src/compas_view2/objects/meshobject.py
@@ -65,15 +65,10 @@ class MeshObject(BufferObject):
 
     """
 
-    def __init__(self, data, color=None,
-                 facecolor=None, linecolor=None, pointcolor=None,
-                 vertices=None, edges=None, faces=None,
+    def __init__(self, data, vertices=None, edges=None, faces=None,
                  hide_coplanaredges=False, **kwargs):
         super().__init__(data,  **kwargs)
         self._mesh = data
-        self.facecolor = facecolor or color
-        self.linecolor = linecolor or color
-        self.pointcolor = pointcolor or color
         self.hide_coplanaredges = hide_coplanaredges
         self.vertices = vertices
         self.edges = edges
@@ -82,10 +77,6 @@ class MeshObject(BufferObject):
     def _points_data(self):
         mesh = self._mesh
         vertex_xyz = {vertex: mesh.vertex_attributes(vertex, 'xyz') for vertex in mesh.vertices()}
-        vertex_color = {
-            vertex: self._mesh.vertex_attribute(vertex, 'color') or self.pointcolor or self.default_color_points
-            for vertex in self._mesh.vertices()
-        }
         positions = []
         colors = []
         elements = []
@@ -93,7 +84,7 @@ class MeshObject(BufferObject):
         vertices = self.vertices or mesh.vertices()
         for vertex in vertices:
             positions.append(vertex_xyz[vertex])
-            colors.append(vertex_color[vertex])
+            colors.append(self.pointcolors.get(vertex, [0, 0, 0]))
             elements.append([i])
             i += 1
         return positions, colors, elements
@@ -101,17 +92,13 @@ class MeshObject(BufferObject):
     def _lines_data(self):
         mesh = self._mesh
         vertex_xyz = {vertex: mesh.vertex_attributes(vertex, 'xyz') for vertex in mesh.vertices()}
-        linecolor = {
-            edge: self._mesh.edge_attribute(edge, 'color') or self.linecolor or self.default_color_lines
-            for edge in self._mesh.edges()
-        }
         positions = []
         colors = []
         elements = []
         i = 0
         edges = self.edges or mesh.edges()
         for u, v in edges:
-            color = linecolor[u, v]
+            color = self.linecolors.get((u, v), [0, 0, 0])
             if self.hide_coplanaredges:
                 # hide the edge if neighbor faces are coplanar
                 fkeys = mesh.edge_faces(u, v)
@@ -132,18 +119,14 @@ class MeshObject(BufferObject):
     def _frontfaces_data(self):
         mesh = self._mesh
         vertex_xyz = {vertex: mesh.vertex_attributes(vertex, 'xyz') for vertex in mesh.vertices()}
-        face_color = {
-            face: self._mesh.face_attribute(face, 'color') or self.facecolor or self.default_color_faces
-            for face in self._mesh.faces()
-        }
         positions = []
         colors = []
         elements = []
         i = 0
         faces = self.faces or mesh.faces()
         for face in faces:
-            color = face_color[face]
             vertices = mesh.face_vertices(face)
+            color = self.facecolors.get(face, [0, 0, 0])
             if len(vertices) == 3:
                 a, b, c = vertices
                 positions.append(vertex_xyz[a])
@@ -189,18 +172,14 @@ class MeshObject(BufferObject):
     def _backfaces_data(self):
         mesh = self._mesh
         vertex_xyz = {vertex: mesh.vertex_attributes(vertex, 'xyz') for vertex in mesh.vertices()}
-        face_color = {
-            face: self._mesh.face_attribute(face, 'color') or self.facecolor or self.default_color_faces
-            for face in self._mesh.faces()
-        }
         positions = []
         colors = []
         elements = []
         i = 0
         faces = self.faces or mesh.faces()
         for face in faces:
-            color = face_color[face]
             vertices = mesh.face_vertices(face)[::-1]
+            color = self.facecolors.get(face, [0, 0, 0])
             if len(vertices) == 3:
                 a, b, c = vertices
                 positions.append(vertex_xyz[a])

--- a/src/compas_view2/objects/meshobject.py
+++ b/src/compas_view2/objects/meshobject.py
@@ -84,7 +84,7 @@ class MeshObject(BufferObject):
         vertices = self.vertices or mesh.vertices()
         for vertex in vertices:
             positions.append(vertex_xyz[vertex])
-            colors.append(self.pointcolors.get(vertex, [0, 0, 0]))
+            colors.append(self.pointcolors.get(vertex, self.pointcolor))
             elements.append([i])
             i += 1
         return positions, colors, elements
@@ -98,7 +98,7 @@ class MeshObject(BufferObject):
         i = 0
         edges = self.edges or mesh.edges()
         for u, v in edges:
-            color = self.linecolors.get((u, v), [0, 0, 0])
+            color = self.linecolors.get((u, v), self.linecolor)
             if self.hide_coplanaredges:
                 # hide the edge if neighbor faces are coplanar
                 fkeys = mesh.edge_faces(u, v)
@@ -126,7 +126,7 @@ class MeshObject(BufferObject):
         faces = self.faces or mesh.faces()
         for face in faces:
             vertices = mesh.face_vertices(face)
-            color = self.facecolors.get(face, [0, 0, 0])
+            color = self.facecolors.get(face, self.facecolor)
             if len(vertices) == 3:
                 a, b, c = vertices
                 positions.append(vertex_xyz[a])
@@ -179,7 +179,7 @@ class MeshObject(BufferObject):
         faces = self.faces or mesh.faces()
         for face in faces:
             vertices = mesh.face_vertices(face)[::-1]
-            color = self.facecolors.get(face, [0, 0, 0])
+            color = self.facecolors.get(face, self.facecolor)
             if len(vertices) == 3:
                 a, b, c = vertices
                 positions.append(vertex_xyz[a])

--- a/src/compas_view2/objects/networkobject.py
+++ b/src/compas_view2/objects/networkobject.py
@@ -25,10 +25,9 @@ class NetworkObject(BufferObject):
         positions = []
         colors = []
         elements = []
-        color = self.default_color_points
         for i, node in enumerate(data.nodes()):
             positions.append(node_xyz[node])
-            colors.append(color)
+            colors.append(self.pointcolors.get(node, self.pointcolor))
             elements.append([i])
         return positions, colors, elements
 
@@ -38,11 +37,11 @@ class NetworkObject(BufferObject):
         positions = []
         colors = []
         elements = []
-        color = self.default_color_lines
         i = 0
         for u, v in data.edges():
             positions.append(node_xyz[u])
             positions.append(node_xyz[v])
+            color = self.linecolors.get((u, v), self.linecolor)
             colors.append(color)
             colors.append(color)
             elements.append([i + 0, i + 1])

--- a/src/compas_view2/objects/nurbssurfaceobject.py
+++ b/src/compas_view2/objects/nurbssurfaceobject.py
@@ -5,15 +5,12 @@ from .bufferobject import BufferObject
 class NurbsSurfaceObject(BufferObject):
     """Object for displaying COMPAS NurbsSurface geometry."""
 
-    def __init__(self, surface, u=100, v=100,
-                 color=None, facecolor=None, linecolor=None, pointcolor=None,
-                 show_edges=False, **kwargs):
+    def __init__(self, surface, u=100, v=100, show_edges=False, **kwargs):
         super().__init__(surface, show_edges=show_edges, **kwargs)
         self._data = surface
         self._triangles = surface.to_triangles(nu=u, nv=v)
-        self.facecolor = facecolor or color or self.default_color_faces
-        self.linecolor = linecolor or color or self.default_color_lines
-        self.pointcolor = pointcolor or color or self.default_color_points
+        self.u = u
+        self.v = v
 
     def update(self):
         self._triangles = self._data.to_triangles(nu=self.u, nv=self.v)
@@ -22,13 +19,13 @@ class NurbsSurfaceObject(BufferObject):
 
     def _points_data(self):
         positions = [list(pt) for pt in flatten(self._data.points)]
-        colors = [self.pointcolor or self.default_color_points for _ in positions]
+        colors = [self.pointcolor for _ in positions]
         elements = [[i] for i in range(len(positions))]
         return positions, colors, elements
 
     def _lines_data(self):
         positions = [list(pt) for pt in flatten(self._data.points)]
-        colors = [self.linecolor or self.default_color_lines for _ in positions]
+        colors = [self.linecolor for _ in positions]
         count = 0
         indexes = []
         for row in self._data.points:
@@ -47,16 +44,14 @@ class NurbsSurfaceObject(BufferObject):
         return positions, colors, elements
 
     def _frontfaces_data(self):
-        color = self.facecolor
         positions = self._triangles
-        colors = [color] * len(self._triangles)
+        colors = [self.facecolor] * len(self._triangles)
         elements = [[i * 3 + 0, i * 3 + 1, i * 3 + 2] for i in range(int(len(self._triangles) / 3))]
         return positions, colors, elements
 
     def _backfaces_data(self):
-        color = self.facecolor
         positions = self._triangles[::-1]
-        colors = [color] * len(self._triangles)
+        colors = [self.facecolor] * len(self._triangles)
         elements = [[i * 3 + 0, i * 3 + 1, i * 3 + 2] for i in range(int(len(self._triangles) / 3))]
         return positions, colors, elements
 

--- a/src/compas_view2/objects/object.py
+++ b/src/compas_view2/objects/object.py
@@ -49,7 +49,7 @@ class Object(ABC):
 
     def __init__(self, data, name=None, is_selected=False, is_visible=True):
         self._data = data
-        self.name = name
+        self.name = name or str(self)
         self.is_selected = is_selected
         self.is_visible = is_visible
         self._instance_color = None

--- a/src/compas_view2/objects/pointcloudobject.py
+++ b/src/compas_view2/objects/pointcloudobject.py
@@ -28,8 +28,8 @@ class PointcloudObject(BufferObject):
         If number of colors does not equal to number of points.
     """
 
-    def __init__(self, data, size=10, colors=None, **kwargs):
-        super().__init__(data, show_points=True, pointsize=size, **kwargs)
+    def __init__(self, data, colors=None, **kwargs):
+        super().__init__(data, show_points=True, **kwargs)
         if colors:
             if len(colors) != len(data):
                 raise ValueError("Number of colors must equal to number of points")

--- a/src/compas_view2/objects/pointcloudobject.py
+++ b/src/compas_view2/objects/pointcloudobject.py
@@ -28,14 +28,15 @@ class PointcloudObject(BufferObject):
         If number of colors does not equal to number of points.
     """
 
-    def __init__(self, data, color=None, colors=None, size=10, **kwargs):
+    def __init__(self, data, size=10, colors=None, **kwargs):
         super().__init__(data, show_points=True, pointsize=size, **kwargs)
-        self.colors = colors or [color or self.default_color_points] * len(data)
-        if len(self.colors) != len(data):
-            raise ValueError("Number of colors must equal to number of points")
+        if colors:
+            if len(colors) != len(data):
+                raise ValueError("Number of colors must equal to number of points")
+            self.pointcolors = colors
 
     def _points_data(self):
         positions = self._data
-        colors = self.colors
+        colors = [self.pointcolors.get(i, self.pointcolor) for i in range(len(positions))]
         elements = [[i] for i in range(len(positions))]
         return positions, colors, elements

--- a/src/compas_view2/objects/pointobject.py
+++ b/src/compas_view2/objects/pointobject.py
@@ -5,13 +5,12 @@ from compas.geometry import Point
 class PointObject(BufferObject):
     """Object for displaying COMPAS point geometry."""
 
-    def __init__(self, data, color=None, size=10, **kwargs):
+    def __init__(self, data, size=None, **kwargs):
         super().__init__(data, show_points=True, pointsize=size, **kwargs)
-        self.color = color
 
     def _points_data(self):
         positions = [self._data]
-        colors = [self.color or self.default_color_points]
+        colors = [self.pointcolor]
         elements = [[0]]
         return positions, colors, elements
 

--- a/src/compas_view2/objects/polylineobject.py
+++ b/src/compas_view2/objects/polylineobject.py
@@ -15,7 +15,7 @@ class PolylineObject(BufferObject):
     def _points_data(self):
         polyline = self._data
         positions = [point for point in polyline.points]
-        colors = [self.pointcolors.get(i, self.pointcolor) for i,_ in enumerate(polyline.points)]
+        colors = [self.pointcolors.get(i, self.pointcolor) for i, _ in enumerate(polyline.points)]
         elements = [[i] for i in range(len(positions))]
         return positions, colors, elements
 

--- a/src/compas_view2/objects/polylineobject.py
+++ b/src/compas_view2/objects/polylineobject.py
@@ -8,23 +8,19 @@ class PolylineObject(BufferObject):
     default_color_points = [0.1, 0.1, 0.1]
     default_color_line = [0.4, 0.4, 0.4]
 
-    def __init__(self, data, close=False, pointcolor=None, linecolor=None, color=None, **kwargs):
+    def __init__(self, data, close=False, **kwargs):
         super().__init__(data, show_lines=True, **kwargs)
-        self.pointcolor = pointcolor or color
-        self.linecolor = linecolor or color
         self.close = close
 
     def _points_data(self):
         polyline = self._data
-        color = self.pointcolor or self.default_color_points
         positions = [point for point in polyline.points]
-        colors = [color for i in range(len(positions))]
+        colors = [self.pointcolors.get(i, self.pointcolor) for i,_ in enumerate(polyline.points)]
         elements = [[i] for i in range(len(positions))]
         return positions, colors, elements
 
     def _lines_data(self):
         polyline = self._data
-        color = self.linecolor or self.default_color_line
         positions = []
         colors = []
         elements = []
@@ -33,9 +29,10 @@ class PolylineObject(BufferObject):
         else:
             lines = pairwise(polyline.points)
         count = 0
-        for pt1, pt2 in lines:
+        for i, (pt1, pt2) in enumerate(lines):
             positions.append(pt1)
             positions.append(pt2)
+            color = self.linecolors.get(i, self.linecolor)
             colors.append(color)
             colors.append(color)
             elements.append([count, count+1])

--- a/src/compas_view2/shaders/120/model.frag
+++ b/src/compas_view2/shaders/120/model.frag
@@ -9,11 +9,19 @@ uniform bool is_lighted;
 uniform bool is_selected;
 uniform vec3 selection_color;
 uniform int element_type;
+uniform vec3 single_color;
+uniform bool use_single_color;
+
 
 void main()
 {   
     float alpha = opacity * object_opacity;
-    vec3 color = vertex_color;
+    vec3 color;
+    if (use_single_color){
+        color = single_color;
+    }else{
+        color = vertex_color;
+    }
     if (is_selected) {
         if (element_type == 0) {color = selection_color*0.9;}
         else if (element_type == 1) {color = selection_color*0.8;}


### PR DESCRIPTION
1. More consistent way of dealing with colors:
Use `pointcolor`, `linecolor`, `facecolor` for single color for all elements
Use `pointcolors`, `linecolors`, `facecolors` for multiple colors per element.
See example at `scripts/v120_colors.py`
```
facecolors = {k: [random(), random(), random()] for k in mesh.faces()}
linecolors = {k: [random(), random(), random()] for k in mesh.edges()}
pointcolors = {k: [random(), random(), random()] for k in mesh.vertices()}

viewer.add(mesh, name="mesh1", show_points=True, facecolors=facecolors, linecolors=linecolors, pointcolors=pointcolors)
viewer.add(mesh2, name="mesh2", show_points=True, facecolor=[1, 0, 0], linecolor=[0, 1, 0], pointcolor=[0, 0, 1])

```
![image](https://user-images.githubusercontent.com/17893605/129708440-ce453414-d45a-43c5-be4b-4fe7cc6e6284.png)

2. Visualisation tab added. Allowing editing in real time without updating the object data. 
![image](https://user-images.githubusercontent.com/17893605/129708833-1c400b4b-b054-403d-a9ab-78f3d19e6301.png)

3. Common Attributes like `xxxcolor` and `show_xxx` are now all concentrated to `BufferObject`, inheritance classes are simplified.