### PR TITLE
fix and flip mouse control camera in vertical direction

### DIFF
--- a/src/compas_view2/scene/camera.py
+++ b/src/compas_view2/scene/camera.py
@@ -249,7 +249,7 @@ class Camera:
 
         """
         if self.view.current == self.view.PERSPECTIVE:
-            self.rotation += [self.rotation_delta * dy, 0, -self.rotation_delta * dx]
+            self.rotation += [-self.rotation_delta * dy, 0, -self.rotation_delta * dx]
 
     def pan(self, dx, dy):
         """Pan the camera based on current mouse movement.


### PR DESCRIPTION
@brgcode @Licini Is there any specific reason that we want the mouse-camera control flipped in the vertical direction? Currently when we move the mouse from left and right the camera the object dragged from the same direction, but this is the opposite in the vertical direction. I find this very unintuitive, so I flip the vertical direction. Hope this makes sense. 