### PR TITLE
add datastore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Added `RobotObject`.
+* add `datastore` to `TreeForm`.
 
 ### Changed
 

--- a/scripts/v120_tree_editable.py
+++ b/scripts/v120_tree_editable.py
@@ -2,11 +2,16 @@ from compas_view2.app import App
 
 viewer = App()
 
-def on_item_edited(self, entry, column, value):
-    print("form", self)
-    print("entry", entry)
-    print("column", column)
-    print("value", value)
+
+def on_item_edited(form, entry, column, value):
+    print("form:\n", form)
+    print("entry:\n", entry)
+    print("column:\n", column)
+    print("value:\n", value)
+    print("datastore:")
+    for row in form.datastore:
+        print(row)
+
 
 data = [
     {"column1": "a", "column2": 1, "on_item_edited": on_item_edited, "some_binded_obj": {}},


### PR DESCRIPTION
- Modified `scripts/v120_tree_editable.py` as a show case

Right now each data store item (row) contains a list of `values`, similarly to ETO form. We can also make them dict to match the input entries, let me know which one you prefer.

<img width="869" alt="image" src="https://user-images.githubusercontent.com/17893605/190395398-1325bcce-b716-4898-bcea-f67cae6892ad.png">
