### PR TITLE
use_vertex_color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Added `RobotObject`.
-* add `datastore` to `TreeForm`.
+* Added `datastore` to `TreeForm`.
 * Added `TabsForm`.
 * Added `BRepObject`.
 * Added `zoom_extents` to `Camera`.
 * Added `expanded` option for `TreeForm` data entries.
 * Added `striped_rows` option for `TreeForm`.
 * Added `option` to display drop down list for `TreeForm` item editing.
-* Aded `on_object_selected` event listener.
+* Added `on_object_selected` event listener.
+* Added `use_vertex_color` option to `MeshObject`.
 
 ### Changed
 

--- a/scripts/v120_face_vertext_color.py
+++ b/scripts/v120_face_vertext_color.py
@@ -1,0 +1,18 @@
+import compas
+
+from compas.datastructures import Mesh
+from compas.colors import Color
+from random import random
+
+from compas_view2.app import App
+
+viewer = App(width=800, height=500)
+
+mesh = Mesh.from_obj(compas.get('faces.obj'))
+
+for vertex in mesh.vertices():
+    mesh.vertex_attribute(vertex, 'color', Color.from_i(random()))
+
+viewer.add(mesh, use_vertex_color=True)
+
+viewer.show()

--- a/src/compas_view2/objects/bufferobject.py
+++ b/src/compas_view2/objects/bufferobject.py
@@ -149,13 +149,13 @@ class BufferObject(Object):
         shader.uniform1i('element_type', 2)
         if hasattr(self, "_frontfaces_buffer") and self.show_faces and not wireframe:
             shader.uniform3f('single_color', self.facecolor)
-            shader.uniform1i('use_single_color', not self.facecolors and not self._is_collection)
+            shader.uniform1i('use_single_color', not self.facecolors and not self._is_collection and not getattr(self, 'use_vertex_color', False))
             shader.bind_attribute('position', self._frontfaces_buffer['positions'])
             shader.bind_attribute('color', self._frontfaces_buffer['colors'])
             shader.draw_triangles(elements=self._frontfaces_buffer['elements'], n=self._frontfaces_buffer['n'], background=self.background)
         if hasattr(self, "_backfaces_buffer") and self.show_faces and not wireframe:
             shader.uniform3f('single_color', self.facecolor)
-            shader.uniform1i('use_single_color', not self.facecolors and not self._is_collection)
+            shader.uniform1i('use_single_color', not self.facecolors and not self._is_collection and not getattr(self, 'use_vertex_color', False))
             shader.bind_attribute('position', self._backfaces_buffer['positions'])
             shader.bind_attribute('color', self._backfaces_buffer['colors'])
             shader.draw_triangles(elements=self._backfaces_buffer['elements'], n=self._backfaces_buffer['n'], background=self.background)

--- a/src/compas_view2/objects/meshobject.py
+++ b/src/compas_view2/objects/meshobject.py
@@ -1,7 +1,7 @@
 from compas.utilities import pairwise
 from compas.geometry import centroid_points
 from compas.geometry import is_coplanar
-
+from compas.colors import Color
 from .bufferobject import BufferObject
 
 
@@ -67,10 +67,11 @@ class MeshObject(BufferObject):
     """
 
     def __init__(self, data, vertices=None, edges=None, faces=None,
-                 hide_coplanaredges=False, **kwargs):
+                 hide_coplanaredges=False, use_vertex_color=False, **kwargs):
         super().__init__(data,  **kwargs)
         self._mesh = data
         self.hide_coplanaredges = hide_coplanaredges
+        self.use_vertex_color = use_vertex_color
         self.vertices = vertices
         self.edges = edges
         self.faces = faces
@@ -120,6 +121,8 @@ class MeshObject(BufferObject):
     def _frontfaces_data(self):
         mesh = self._mesh
         vertex_xyz = {vertex: mesh.vertex_attributes(vertex, 'xyz') for vertex in mesh.vertices()}
+        if self.use_vertex_color:
+            vertex_color = {vertex: mesh.vertex_attribute(vertex, 'color') or Color.grey() for vertex in mesh.vertices()}
         positions = []
         colors = []
         elements = []
@@ -133,9 +136,14 @@ class MeshObject(BufferObject):
                 positions.append(vertex_xyz[a])
                 positions.append(vertex_xyz[b])
                 positions.append(vertex_xyz[c])
-                colors.append(color)
-                colors.append(color)
-                colors.append(color)
+                if self.use_vertex_color:
+                    colors.append(vertex_color[a])
+                    colors.append(vertex_color[b])
+                    colors.append(vertex_color[c])
+                else:
+                    colors.append(color)
+                    colors.append(color)
+                    colors.append(color)
                 elements.append([i + 0, i + 1, i + 2])
                 i += 3
             elif len(vertices) == 4:
@@ -146,12 +154,20 @@ class MeshObject(BufferObject):
                 positions.append(vertex_xyz[a])
                 positions.append(vertex_xyz[c])
                 positions.append(vertex_xyz[d])
-                colors.append(color)
-                colors.append(color)
-                colors.append(color)
-                colors.append(color)
-                colors.append(color)
-                colors.append(color)
+                if self.use_vertex_color:
+                    colors.append(vertex_color[a])
+                    colors.append(vertex_color[b])
+                    colors.append(vertex_color[c])
+                    colors.append(vertex_color[a])
+                    colors.append(vertex_color[c])
+                    colors.append(vertex_color[d])
+                else:
+                    colors.append(color)
+                    colors.append(color)
+                    colors.append(color)
+                    colors.append(color)
+                    colors.append(color)
+                    colors.append(color)
                 elements.append([i + 0, i + 1, i + 2])
                 elements.append([i + 3, i + 4, i + 5])
                 i += 6
@@ -162,17 +178,23 @@ class MeshObject(BufferObject):
                     positions.append(a)
                     positions.append(b)
                     positions.append(c)
-                    colors.append(color)
-                    colors.append(color)
-                    colors.append(color)
+                    if self.use_vertex_color:
+                        colors.append(vertex_color[a])
+                        colors.append(vertex_color[b])
+                        colors.append(vertex_color[c])
+                    else:
+                        colors.append(color)
+                        colors.append(color)
+                        colors.append(color)
                     elements.append([i + 0, i + 1, i + 2])
                     i += 3
-
         return positions, colors, elements
 
     def _backfaces_data(self):
         mesh = self._mesh
         vertex_xyz = {vertex: mesh.vertex_attributes(vertex, 'xyz') for vertex in mesh.vertices()}
+        if self.use_vertex_color:
+            vertex_color = {vertex: mesh.vertex_attribute(vertex, 'color') or Color.grey() for vertex in mesh.vertices()}
         positions = []
         colors = []
         elements = []
@@ -186,9 +208,14 @@ class MeshObject(BufferObject):
                 positions.append(vertex_xyz[a])
                 positions.append(vertex_xyz[b])
                 positions.append(vertex_xyz[c])
-                colors.append(color)
-                colors.append(color)
-                colors.append(color)
+                if self.use_vertex_color:
+                    colors.append(vertex_color[a])
+                    colors.append(vertex_color[b])
+                    colors.append(vertex_color[c])
+                else:
+                    colors.append(color)
+                    colors.append(color)
+                    colors.append(color)
                 elements.append([i + 0, i + 1, i + 2])
                 i += 3
             elif len(vertices) == 4:
@@ -199,12 +226,20 @@ class MeshObject(BufferObject):
                 positions.append(vertex_xyz[a])
                 positions.append(vertex_xyz[c])
                 positions.append(vertex_xyz[d])
-                colors.append(color)
-                colors.append(color)
-                colors.append(color)
-                colors.append(color)
-                colors.append(color)
-                colors.append(color)
+                if self.use_vertex_color:
+                    colors.append(vertex_color[a])
+                    colors.append(vertex_color[b])
+                    colors.append(vertex_color[c])
+                    colors.append(vertex_color[a])
+                    colors.append(vertex_color[c])
+                    colors.append(vertex_color[d])
+                else:
+                    colors.append(color)
+                    colors.append(color)
+                    colors.append(color)
+                    colors.append(color)
+                    colors.append(color)
+                    colors.append(color)
                 elements.append([i + 0, i + 1, i + 2])
                 elements.append([i + 3, i + 4, i + 5])
                 i += 6
@@ -215,9 +250,14 @@ class MeshObject(BufferObject):
                     positions.append(a)
                     positions.append(b)
                     positions.append(c)
-                    colors.append(color)
-                    colors.append(color)
-                    colors.append(color)
+                    if self.use_vertex_color:
+                        colors.append(vertex_color[a])
+                        colors.append(vertex_color[b])
+                        colors.append(vertex_color[c])
+                    else:
+                        colors.append(color)
+                        colors.append(color)
+                        colors.append(color)
                     elements.append([i + 0, i + 1, i + 2])
                     i += 3
         return positions, colors, elements


### PR DESCRIPTION
Allow something like this to show vertex color with interpolation in faces. #134 
```python
for vertex in mesh.vertices():
    mesh.vertex_attribute(vertex, 'color', Color.from_i(random()))

viewer.add(mesh, use_vertex_color=True)
```

<img width="804" alt="image" src="https://user-images.githubusercontent.com/17893605/194317625-1112a5e8-1dbf-41c4-bfd8-4b105258d73b.png">
