### PR TITLE
add scale and lookat to camera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added `Scale` factor for `Camera`.
+* Added `look_at` function to `Camera`
 * Added `compas_view2.values.Value` class.
 * Added `compas_view2.values.BoolValue` class.
 * Added `compas_view2.values.IntValue` class.

--- a/scripts/v120_camera_lookat.py
+++ b/scripts/v120_camera_lookat.py
@@ -1,0 +1,11 @@
+from compas_view2.app import App
+from compas.geometry import Sphere
+
+viewer = App()
+
+center = [0, 0, 5]
+viewer.add(Sphere(center, 1))
+
+viewer.view.camera.position = [center[0] + 5, center[1], center[2] + 3]
+viewer.view.camera.look_at(center)
+viewer.run()

--- a/scripts/v120_camera_scale.py
+++ b/scripts/v120_camera_scale.py
@@ -1,0 +1,10 @@
+from compas_view2.app import App
+from compas.geometry import Sphere
+
+
+viewer = App()
+viewer.add(Sphere([0, 0, 0], 0.01))
+viewer.view.camera.scale = 0.01
+viewer.view.camera.zoom_extents()
+
+viewer.run()


### PR DESCRIPTION
1. Adding scale factor to camera, which will multiply near, far and pan_delta, see `scripts/v120_camera_scale.py`. We need try a bit to see what number works best for what unit. Also the definition for units might be more relevant to live in code base of inheriting class like ifc_viewer.

2. Added `look_at` function for better camera positioning. See `scripts/v120_camera_lookat.py`. Right now the camera has been setup in the "target prioritised" way, which means setting position will automatically update rotation to maintain target unchanged. But setting target directly will end up updating position (like a shifting action), this might be the reason it was previously not working as expected. `look_at` allows look at new target at same time maintaining current position.