### PR TITLE
Absolute text heigh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-
+ - Added `absolute_height` option to the text object.
 ### Changed
 
 ### Removed

--- a/scripts/v120_texts.py
+++ b/scripts/v120_texts.py
@@ -9,7 +9,7 @@ viewer.add(t)
 t = Text("123", [3, 0, 0], height=50)
 viewer.add(t)
 
-t = Text("ABC", [3, 3, 0], height=100)
+t = Text("ABC", [3, 3, 0], height=20, absolute_height=True)
 viewer.add(t, color=(1, 0, 0))
 
 viewer.show()

--- a/src/compas_view2/objects/textobject.py
+++ b/src/compas_view2/objects/textobject.py
@@ -75,9 +75,14 @@ class TextObject(Object):
         )
         return texture
 
-    def calculate_text_height (self, camera_position):
+    def calculate_text_height(self, camera_position):
         if self._data.absolute_height:
-            return  int((10*self._data.height)/np.linalg.norm(np.array(self._data.position) - np.array([camera_position.x, camera_position.y, camera_position.z])))
+            return int(
+                (10 * self._data.height)
+                / np.linalg.norm(
+                    np.array(self._data.position) - np.array([camera_position.x, camera_position.y, camera_position.z])
+                )
+            )
 
         else:
             return self._data.height
@@ -87,7 +92,7 @@ class TextObject(Object):
         shader.enable_attribute("position")
         shader.uniform4x4("transform", self.matrix)
         shader.uniform1f("object_opacity", self.opacity)
-        shader.uniform1i("text_height",self.calculate_text_height(camera_position))
+        shader.uniform1i("text_height", self.calculate_text_height(camera_position))
         shader.uniform1i("text_num", len(self._data.text))
         shader.uniform3f("text_color", self.color)
         shader.uniformTex("text_texture", self._text_buffer["text_texture"])

--- a/src/compas_view2/objects/textobject.py
+++ b/src/compas_view2/objects/textobject.py
@@ -75,12 +75,19 @@ class TextObject(Object):
         )
         return texture
 
-    def draw(self, shader):
+    def calculate_text_height (self, camera_position):
+        if self._data.absolute_height:
+            return  int((10*self._data.height)/np.linalg.norm(np.array(self._data.position) - np.array([camera_position.x, camera_position.y, camera_position.z])))
+
+        else:
+            return self._data.height
+
+    def draw(self, shader, camera_position):
         """Draw the object from its buffers"""
         shader.enable_attribute("position")
         shader.uniform4x4("transform", self.matrix)
         shader.uniform1f("object_opacity", self.opacity)
-        shader.uniform1i("text_height", self._data.height)
+        shader.uniform1i("text_height",self.calculate_text_height(camera_position))
         shader.uniform1i("text_num", len(self._data.text))
         shader.uniform3f("text_color", self.color)
         shader.uniformTex("text_texture", self._text_buffer["text_texture"])

--- a/src/compas_view2/shapes/text.py
+++ b/src/compas_view2/shapes/text.py
@@ -5,8 +5,9 @@ from compas.geometry import Shape
 class Text(Shape):
     """ """
 
-    def __init__(self, text, position=[0, 0, 0], height=50):
+    def __init__(self, text, position=[0, 0, 0], height=50, absolute_height=False):
         super().__init__()
         self.text = text
         self.position = Vector(*position)
         self.height = height
+        self.absolute_height = absolute_height

--- a/src/compas_view2/views/view120.py
+++ b/src/compas_view2/views/view120.py
@@ -171,7 +171,7 @@ class View120(View):
             obj = self.objects[guid]
             if isinstance(obj, TextObject):
                 if obj.is_visible:
-                    obj.draw(self.shader_text)
+                    obj.draw(self.shader_text, self.camera.position)
         self.shader_text.release()
 
         # draw 2D box for multi-selection


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
![2023-10-10-04-19-55-07](https://github.com/compas-dev/compas_view2/assets/57562250/1420bef9-f4bf-49d0-ae47-f51b9e19869c)

### What type of change is this?

- [x] Added the `absolute_heigh` option to the `Text` object.

### Checklist

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
