### PR TITLE
sphinx-qt-documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+* Added `sphinx-qt-documentation` for doc build.
 
 ### Changed
 
@@ -19,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 
-* Added `viewport` and `camera` in the config
+* Added `viewport` and `camera` in the config.
 * Added the update method for the `textobject`.
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ flake8
 invoke >=0.14
 isort
 sphinx_compas2_theme
+sphinx_qt_documentation
 twine
 wheel
 -e .

--- a/src/compas_view2/views/view.py
+++ b/src/compas_view2/views/view.py
@@ -13,9 +13,9 @@ class View(QtWidgets.QOpenGLWidget):
 
     Parameters
     ----------
-    app: :class:`compas_view2.app.App`
+    app : :class:`compas_view2.app.App`
         The parent application of the view.
-    view_config: dict
+    view_config : dict
         The view configuration.
     """
 


### PR DESCRIPTION
after merging this: https://github.com/compas-dev/compas_viewer/pull/11, in the mean time. we can also update the doc build of the `view2`. 

while looks like the Qt website is still unlinked...

![2023-12-12-21-16-32-02](https://github.com/compas-dev/compas_view2/assets/57562250/a8bdd5f1-973d-408e-9ad7-9f23cfadc762)

![image](https://github.com/compas-dev/compas_view2/assets/57562250/48f3622e-427f-4ba6-b839-2cd4afaa5e03)

